### PR TITLE
Implement DELETE precondition checks for If-Match header

### DIFF
--- a/cmd/erasure-object-conditional_test.go
+++ b/cmd/erasure-object-conditional_test.go
@@ -148,3 +148,160 @@ func TestPutObjectConditionalWithReadQuorumFailure(t *testing.T) {
 		}
 	})
 }
+
+// TestDeleteObjectConditional tests that conditional DeleteObject
+// operations (with if-match via CheckPrecondFn) behave correctly
+// at the erasure storage layer.
+func TestDeleteObjectConditional(t *testing.T) {
+	ctx := context.Background()
+
+	obj, fsDirs, err := prepareErasure16(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Shutdown(context.Background())
+	defer removeRoots(fsDirs)
+
+	bucket := "test-bucket"
+	object := "test-object"
+
+	err = obj.MakeBucket(ctx, bucket, MakeBucketOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put an initial object so it exists
+	_, err = obj.PutObject(ctx, bucket, object,
+		mustGetPutObjReader(t, bytes.NewReader([]byte("test-value")),
+			int64(len("test-value")), "", ""), ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get object info to capture the ETag
+	objInfo, err := obj.GetObjectInfo(ctx, bucket, object, ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingETag := objInfo.ETag
+
+	t.Run("if-match with wrong ETag should fail", func(t *testing.T) {
+		opts := ObjectOptions{
+			CheckPrecondFn: func(oi ObjectInfo) bool {
+				return oi.ETag != "wrong-etag"
+			},
+		}
+
+		_, err := obj.DeleteObject(ctx, bucket, object, opts)
+		if _, ok := err.(PreConditionFailed); !ok {
+			t.Errorf("Expected PreConditionFailed error, got: %v", err)
+		}
+
+		// Verify object still exists after failed conditional delete
+		_, err = obj.GetObjectInfo(ctx, bucket, object, ObjectOptions{})
+		if err != nil {
+			t.Errorf("Object should still exist after failed conditional delete, got: %v", err)
+		}
+	})
+
+	t.Run("if-match with correct ETag should succeed", func(t *testing.T) {
+		opts := ObjectOptions{
+			CheckPrecondFn: func(oi ObjectInfo) bool {
+				return oi.ETag != existingETag
+			},
+		}
+
+		_, err := obj.DeleteObject(ctx, bucket, object, opts)
+		if err != nil {
+			t.Errorf("Expected successful delete with matching ETag, got: %v", err)
+		}
+	})
+
+	t.Run("if-match on non-existent object should return error", func(t *testing.T) {
+		opts := ObjectOptions{
+			HasIfMatch: true,
+			CheckPrecondFn: func(oi ObjectInfo) bool {
+				return oi.ETag != "some-etag"
+			},
+		}
+
+		_, err := obj.DeleteObject(ctx, bucket, "non-existent-object", opts)
+		if err == nil {
+			t.Error("Expected error for If-Match on non-existent object, got nil")
+		}
+		if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
+			// This is the expected behavior — the object doesn't exist,
+			// so the If-Match precondition cannot be satisfied.
+		} else {
+			t.Errorf("Expected ObjectNotFound/VersionNotFound error, got: %v", err)
+		}
+	})
+}
+
+// TestDeleteObjectConditionalWithReadQuorumFailure tests that conditional
+// DeleteObject operations (with if-match) do NOT proceed
+// when read quorum cannot be reached, because we cannot verify the ETag.
+func TestDeleteObjectConditionalWithReadQuorumFailure(t *testing.T) {
+	ctx := context.Background()
+
+	obj, fsDirs, err := prepareErasure16(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Shutdown(context.Background())
+	defer removeRoots(fsDirs)
+
+	z := obj.(*erasureServerPools)
+	xl := z.serverPools[0].sets[0]
+
+	bucket := "test-bucket"
+	object := "test-object"
+
+	err = obj.MakeBucket(ctx, bucket, MakeBucketOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Put an initial object so it exists
+	_, err = obj.PutObject(ctx, bucket, object,
+		mustGetPutObjReader(t, bytes.NewReader([]byte("test-value")),
+			int64(len("test-value")), "", ""), ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	objInfo, err := obj.GetObjectInfo(ctx, bucket, object, ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existingETag := objInfo.ETag
+
+	// Simulate read quorum failure by taking enough disks offline.
+	// With 16 disks (EC 8+8), read quorum is 9. Taking 8 disks offline leaves only 8,
+	// which is below read quorum but still has write quorum — triggering the tryDel path.
+	erasureDisks := xl.getDisks()
+	z.serverPools[0].erasureDisksMu.Lock()
+	xl.getDisks = func() []StorageAPI {
+		for i := range erasureDisks[:8] {
+			erasureDisks[i] = nil
+		}
+		return erasureDisks
+	}
+	z.serverPools[0].erasureDisksMu.Unlock()
+
+	t.Run("if-match should fail when read quorum lost", func(t *testing.T) {
+		// Even with the correct ETag, we must NOT delete because we can't
+		// verify the current object state due to read quorum failure.
+		opts := ObjectOptions{
+			HasIfMatch: true,
+			CheckPrecondFn: func(oi ObjectInfo) bool {
+				return oi.ETag != existingETag
+			},
+		}
+
+		_, err := obj.DeleteObject(ctx, bucket, object, opts)
+		if err == nil {
+			t.Error("Expected error when if-match is used with quorum failure, got nil (object may have been deleted without ETag verification)")
+		}
+	})
+}

--- a/cmd/erasure-object.go
+++ b/cmd/erasure-object.go
@@ -1993,6 +1993,23 @@ func (er erasureObjects) DeleteObject(ctx context.Context, bucket, object string
 		}
 	}
 
+	if opts.CheckPrecondFn != nil {
+		if gerr != nil {
+			if isErrObjectNotFound(gerr) || isErrVersionNotFound(gerr) {
+				// If-Match on a missing object cannot be satisfied.
+				if opts.HasIfMatch {
+					return objInfo, gerr
+				}
+			} else {
+				// For any other error (e.g. quorum errors), do not proceed with
+				// conditional delete without a verified ObjectInfo/ETag.
+				return objInfo, gerr
+			}
+		} else if opts.CheckPrecondFn(goi) {
+			return objInfo, PreConditionFailed{}
+		}
+	}
+
 	if opts.EvalMetadataFn != nil {
 		dsc, err := opts.EvalMetadataFn(&goi, gerr)
 		if err != nil {

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -77,7 +77,7 @@ type ObjectOptions struct {
 	MaxParts            int                 // used in GetObjectAttributes. Signals how many parts we should return
 	PartNumberMarker    int                 // used in GetObjectAttributes. Signals the part number after which results should be returned
 	PartNumber          int                 // only useful in case of GetObject/HeadObject
-	CheckPrecondFn      CheckPreconditionFn // only set during GetObject/HeadObject/CopyObjectPart preconditional valuation
+	CheckPrecondFn      CheckPreconditionFn // optional precondition check for conditional requests (If-Match, If-None-Match, etc.)
 	EvalMetadataFn      EvalMetadataFn      // only set for retention settings, meant to be used only when updating metadata in-place.
 	DeleteReplication   ReplicationState    // Represents internal replication state needed for Delete replication
 	Transition          TransitionOptions

--- a/cmd/object-handlers-common.go
+++ b/cmd/object-handlers-common.go
@@ -228,6 +228,30 @@ func writeHeadersPrecondition(w http.ResponseWriter, objInfo ObjectInfo) {
 	}
 }
 
+// Validates the preconditions for DELETE. Returns true if DELETE operation should not proceed.
+// Preconditions supported are:
+//
+//	If-Match
+func checkPreconditionsDELETE(ctx context.Context, w http.ResponseWriter, r *http.Request, objInfo ObjectInfo, opts ObjectOptions) bool {
+	// Return false for methods other than DELETE.
+	if r.Method != http.MethodDelete {
+		return false
+	}
+
+	// If-Match : Delete the object only if its entity tag (ETag) is the same as the one specified;
+	// otherwise return a 412 (precondition failed).
+	ifMatchETagHeader := r.Header.Get(xhttp.IfMatch)
+	if ifMatchETagHeader != "" {
+		if !isETagEqual(objInfo.ETag, ifMatchETagHeader) {
+			writeHeadersPrecondition(w, objInfo)
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrPreconditionFailed), r.URL)
+			return true
+		}
+	}
+
+	return false
+}
+
 // Validates the preconditions. Returns true if GET/HEAD operation should not proceed.
 // Preconditions supported are:
 //

--- a/cmd/object-handlers-common_test.go
+++ b/cmd/object-handlers-common_test.go
@@ -179,3 +179,80 @@ func TestCheckPreconditions(t *testing.T) {
 		})
 	}
 }
+
+// Tests - checkPreconditionsDELETE()
+func TestCheckPreconditionsDELETE(t *testing.T) {
+	objInfo := ObjectInfo{ETag: "abc123"}
+
+	testCases := []struct {
+		name         string
+		method       string
+		ifMatch      string
+		expectedFlag bool
+		expectedCode int
+	}{
+		// Non-DELETE method should always return false
+		{
+			name:         "Non-DELETE method ignored",
+			method:       http.MethodGet,
+			ifMatch:      "abc123",
+			expectedFlag: false,
+			expectedCode: 200,
+		},
+		// If-Match with matching ETag — precondition passes, delete proceeds
+		{
+			name:         "If-Match matching ETag",
+			method:       http.MethodDelete,
+			ifMatch:      "abc123",
+			expectedFlag: false,
+			expectedCode: 200,
+		},
+		// If-Match with non-matching ETag — precondition fails, 412
+		{
+			name:         "If-Match non-matching ETag",
+			method:       http.MethodDelete,
+			ifMatch:      "wrong-etag",
+			expectedFlag: true,
+			expectedCode: 412,
+		},
+		// If-Match with wildcard — always matches
+		{
+			name:         "If-Match wildcard",
+			method:       http.MethodDelete,
+			ifMatch:      "*",
+			expectedFlag: false,
+			expectedCode: 200,
+		},
+		// If-Match with quoted ETag — should still match
+		{
+			name:         "If-Match quoted ETag",
+			method:       http.MethodDelete,
+			ifMatch:      "\"abc123\"",
+			expectedFlag: false,
+			expectedCode: 200,
+		},
+		// No conditional headers — no precondition check
+		{
+			name:         "No conditional headers",
+			method:       http.MethodDelete,
+			expectedFlag: false,
+			expectedCode: 200,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(tc.method, "/bucket/a", bytes.NewReader([]byte{}))
+			if tc.ifMatch != "" {
+				request.Header.Set(xhttp.IfMatch, tc.ifMatch)
+			}
+			actualFlag := checkPreconditionsDELETE(t.Context(), recorder, request, objInfo, ObjectOptions{})
+			if tc.expectedFlag != actualFlag {
+				t.Errorf("test: %s, got flag: %v, want: %v", tc.name, actualFlag, tc.expectedFlag)
+			}
+			if tc.expectedCode != recorder.Code {
+				t.Errorf("test: %s, got code: %d, want: %d", tc.name, recorder.Code, tc.expectedCode)
+			}
+		})
+	}
+}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2611,6 +2611,19 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
+	ifMatch := r.Header.Get(xhttp.IfMatch)
+
+	if ifMatch != "" {
+		opts.HasIfMatch = true
+		opts.CheckPrecondFn = func(oi ObjectInfo) bool {
+			if _, err := DecryptObjectInfo(&oi, r); err != nil {
+				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+				return true
+			}
+			return checkPreconditionsDELETE(ctx, w, r, oi, opts)
+		}
+	}
+
 	rcfg, _ := globalBucketObjectLockSys.Get(bucket)
 	if rcfg.LockEnabled && opts.DeletePrefix {
 		apiErr := toAPIError(ctx, errInvalidArgument)
@@ -2675,7 +2688,17 @@ func (api objectAPIHandlers) DeleteObjectHandler(w http.ResponseWriter, r *http.
 			writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
 			return
 		}
+		if _, ok := err.(PreConditionFailed); ok {
+			// Request was aborted by CheckPrecondFn (e.g. precondition, auth/decrypt).
+			// Response has already been written by the closure; do not write another.
+			return
+		}
 		if isErrObjectNotFound(err) || isErrVersionNotFound(err) {
+			if opts.HasIfMatch {
+				// If-Match conditional delete on a non-existent object should fail.
+				writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+				return
+			}
 			// Send an event when the object is not found
 			objInfo.Name = object
 			objInfo.VersionID = opts.VersionID

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -3516,6 +3516,57 @@ func testAPIDeleteObjectHandler(obj ObjectLayer, instanceType, bucketName string
 		}
 	}
 
+	// Test DELETE precondition checks (If-Match).
+	// Upload a dedicated object so that the tests below have a known ETag to work with.
+	precondObjectName := "test-precond-object"
+	precondData := generateBytesData(1 * humanize.MiByte)
+	_, err = obj.PutObject(context.Background(), bucketName, precondObjectName,
+		mustGetPutObjReader(t, bytes.NewReader(precondData), int64(len(precondData)), "", ""),
+		ObjectOptions{})
+	if err != nil {
+		t.Fatalf("MinIO %s: Failed to put precondition test object: %v", instanceType, err)
+	}
+
+	// (1) If-Match with a wrong ETag must return 412 and the object must remain.
+	rec1 := httptest.NewRecorder()
+	req1, err := newTestSignedRequestV4(http.MethodDelete, getDeleteObjectURL("", bucketName, precondObjectName),
+		0, nil, credentials.AccessKey, credentials.SecretKey,
+		map[string]string{xhttp.IfMatch: "wrong-etag"})
+	if err != nil {
+		t.Fatalf("MinIO %s: Failed to create DELETE request with wrong If-Match: %v", instanceType, err)
+	}
+	apiRouter.ServeHTTP(rec1, req1)
+	if rec1.Code != http.StatusPreconditionFailed {
+		t.Errorf("MinIO %s: If-Match (wrong ETag): expected status %d, got %d",
+			instanceType, http.StatusPreconditionFailed, rec1.Code)
+	}
+	// The object must still exist after a failed conditional delete.
+	if _, err = obj.GetObjectInfo(context.Background(), bucketName, precondObjectName, ObjectOptions{}); err != nil {
+		t.Errorf("MinIO %s: If-Match (wrong ETag): object should still exist after failed delete, got err: %v",
+			instanceType, err)
+	}
+
+	// (2) If-Match on a non-existent key must return 404 with a NoSuchKey error code.
+	rec3 := httptest.NewRecorder()
+	req3, err := newTestSignedRequestV4(http.MethodDelete, getDeleteObjectURL("", bucketName, "non-existent-key"),
+		0, nil, credentials.AccessKey, credentials.SecretKey,
+		map[string]string{xhttp.IfMatch: "some-etag-value"})
+	if err != nil {
+		t.Fatalf("MinIO %s: Failed to create DELETE request for non-existent key with If-Match: %v", instanceType, err)
+	}
+	apiRouter.ServeHTTP(rec3, req3)
+	if rec3.Code != http.StatusNotFound {
+		t.Errorf("MinIO %s: If-Match on missing key: expected status %d, got %d",
+			instanceType, http.StatusNotFound, rec3.Code)
+	}
+	var apiErr3 APIErrorResponse
+	if xmlErr := xml.Unmarshal(rec3.Body.Bytes(), &apiErr3); xmlErr != nil {
+		t.Errorf("MinIO %s: If-Match on missing key: failed to parse error response: %v", instanceType, xmlErr)
+	} else if apiErr3.Code != "NoSuchKey" {
+		t.Errorf("MinIO %s: If-Match on missing key: expected S3 error code %q, got %q",
+			instanceType, "NoSuchKey", apiErr3.Code)
+	}
+
 	// Test for Anonymous/unsigned http request.
 	anonReq, err := newTestRequest(http.MethodDelete, getDeleteObjectURL("", bucketName, anonObjectName), 0, nil)
 	if err != nil {


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add support for the `If-Match` conditional header on the `DeleteObject` API operation, as [specified by AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html). (fixes pgsty/minio#10)

When `If-Match` is provided, the object is deleted only if its ETag matches the specified value; otherwise a `412 Precondition Failed` response is returned. When `If-Match` is specified and the object does not exist, a `404 NoSuchKey` error is returned instead of the usual `204 No Content`.

This follows the same two-tier precondition check pattern already used by `PutObject` and `GetObject`:

1. **HTTP handler layer** (`DeleteObjectHandler`) — reads the `If-Match` header, sets `opts.CheckPrecondFn` closure and `opts.HasIfMatch` flag.
2. **Storage layer** (`erasureObjects.DeleteObject`) — evaluates `CheckPrecondFn` atomically after fetching the latest `ObjectInfo` via `getObjectInfoAndQuorum`, before proceeding with the actual deletion. Non-NotFound errors (e.g. `InsufficientReadQuorum`) are propagated to prevent unverified deletes.

Source changes across 4 files:

- **`cmd/object-handlers-common.go`** — new `checkPreconditionsDELETE()` function that checks `If-Match` for DELETE requests.
- **`cmd/object-handlers.go`** — `DeleteObjectHandler` now parses the `If-Match` header and sets the precondition function. Error handling updated: `PreConditionFailed` returns early; `If-Match` on a non-existent object returns `NoSuchKey` error instead of `204 No Content`.
- **`cmd/erasure-object.go`** — `DeleteObject` evaluates `CheckPrecondFn` after `getObjectInfoAndQuorum` and before `EvalMetadataFn`, with proper quorum-error propagation.
- **`cmd/object-api-interface.go`** — updated `CheckPrecondFn` field comment to be generic.

Test changes across 3 files:

- **`cmd/object-handlers-common_test.go`** — `TestCheckPreconditionsDELETE`: 6 unit test cases for the precondition function (non-DELETE ignored, matching/non-matching/wildcard/quoted ETags, no headers).
- **`cmd/erasure-object-conditional_test.go`** — `TestDeleteObjectConditional`: 3 erasure-layer integration tests (wrong ETag → fail, correct ETag → succeed, missing object → error). `TestDeleteObjectConditionalWithReadQuorumFailure`: 1 test verifying that conditional delete is blocked when read quorum is lost.
- **`cmd/object-handlers_test.go`** — 2 handler-level tests added to `TestAPIDeleteObjectHandler` (wrong `If-Match` → 412 and object remains; `If-Match` on missing key → 404 `NoSuchKey`).

## Motivation and Context

AWS S3 supports the `If-Match` conditional header on `DeleteObject` operations, returning `412 Precondition Failed` when the condition is not met. This enables safe concurrent delete workflows where callers can ensure they only delete a specific known version of an object (by ETag), preventing accidental deletion of an object that was updated between a read and a delete.

MinIO already supports conditional headers for `GetObject`, `HeadObject`, `PutObject`, `CopyObject`, and multipart operations — but `DeleteObject` was missing `If-Match` support entirely. There were no checks, no TODOs, and no code paths for conditional headers in the delete flow.

## How to test this PR?

### Reproduce the bug (before the fix)

1. Start an unpatched MinIO server:
   ```bash
   docker run -d -p 9000:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
     minio/minio:RELEASE.2025-12-03T12-00-00Z server /data
   ```
2. Create a bucket and upload an object.
3. Send a `DeleteObject` request with `If-Match: "wrong-etag"` (an ETag that does not match the object).
4. Observe that the object is deleted with `204 No Content` instead of being rejected with `412 Precondition Failed`.

Minimal reproduction using .NET 10 + AWS SDK (save as `test-ifmatch.cs`, run with `dotnet run --file test-ifmatch.cs`):

```csharp
#!/usr/bin/env dotnet run
#:package AWSSDK.S3@4.*

using Amazon.S3;
using Amazon.S3.Model;
using Amazon.Runtime;

var config = new AmazonS3Config { ServiceURL = "http://localhost:9000", ForcePathStyle = true };
var s3 = new AmazonS3Client(new BasicAWSCredentials("minioadmin", "minioadmin"), config);

// Upload a test object
await s3.PutObjectAsync(new PutObjectRequest {
    BucketName = "testbucket", Key = "test.txt", ContentBody = "hello"
});
var etag = (await s3.GetObjectMetadataAsync("testbucket", "test.txt")).ETag;
Console.WriteLine($"ETag: {etag}");

// DELETE with wrong ETag — should return 412 Precondition Failed, but MinIO returns 204
try {
    await s3.DeleteObjectAsync(new DeleteObjectRequest {
        BucketName = "testbucket", Key = "test.txt", IfMatch = "\"wrong-etag\""
    });
    Console.WriteLine("BUG: object deleted even though ETag does not match!");
} catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed) {
    Console.WriteLine("OK: 412 Precondition Failed (expected behavior)");
}
```

**Before fix:** `BUG: object deleted even though ETag does not match!`
**After fix:** `OK: 412 Precondition Failed (expected behavior)`

### Unit tests

```bash
go test ./cmd/ -run "TestCheckPreconditionsDELETE|TestDeleteObjectConditional|TestAPIDeleteObjectHandler" -v -count=1
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [x] Unit tests added/updated
- [x] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
