### PR TITLE
fix: implement Flush on trackingResponseWriter

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -1060,6 +1060,12 @@ func (w *trackingResponseWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
+func (w *trackingResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 func (w *trackingResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }

--- a/cmd/api-response_test.go
+++ b/cmd/api-response_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/gzhttp"
+	xhttp "github.com/minio/minio/internal/http"
 )
 
 // Tests object location.
@@ -156,6 +157,29 @@ func TestTrackingResponseWriter(t *testing.T) {
 	// Check that Unwrap works
 	if trw.Unwrap() != rw {
 		t.Fatalf("Unwrap returned wrong result: %v", trw.Unwrap())
+	}
+}
+
+func TestTrackingResponseWriterFlush(t *testing.T) {
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+
+	trw.Flush()
+	if trw.headerWritten {
+		t.Fatal("Flush() should not set headerWritten")
+	}
+
+	// Simulate the ListenNotificationHandler flow: WriteHeader, Write, Flush
+	trw.WriteHeader(http.StatusOK)
+	_, err := trw.Write([]byte("event data"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	xhttp.Flush(trw)
+
+	if !rw.Flushed {
+		t.Fatalf("xhttp.Flush should have flushed the underlying ResponseRecorder via trackingResponseWriter.Flush()")
 	}
 }
 


### PR DESCRIPTION
## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description

Add `http.Flusher` interface implementation to `trackingReponseWriter` so that streaming handlers like `ListenBucketNotification` continue to work when the double-response guard is active.

Commit 52eee5a2f introduced `trackingReponseWrite` to prevent double HTTP responses on a single request. However `trackingReponseWriter` did not implement the `http.Flusher` interface. This caused `xhttp.Flush(w)` which uses a type assertion `w.(http.Flushed)` to become a no-op when the wrapper was active. As a result, streaming handlers like `ListenBucketNotification` (used by `mcli watch`) would buffer event data indefinitely without ever flushing it to the client, making the notification listener appear broken.


## Motivation and Context

`ListenBucketNotification` uses a long-lived HTTP connection with Server-Sent Events. After writing each event, it calls `xhttp.flush(w)` to immediately push data to the client. Without `http.Flusher` on `trackingResponseWriter`, the flush was silently skipped, and events never reached the client.

## How to test this PR?

1. Start a MinIO server
2. Run `mcli watch myminio/bucket`
3. Push file to the bucket
4. You should receive events

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] Fixes a regression (52eee5a2f)
- [x] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
