### PR TITLE
fix: ListObjects should return NoSuchBucket for prefix on missing bucket

### DIFF
--- a/cmd/bucket-handlers_test.go
+++ b/cmd/bucket-handlers_test.go
@@ -24,11 +24,51 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
 	"github.com/minio/minio/internal/auth"
 )
+
+func TestListObjectsNonExistentBucketHandler(t *testing.T) {
+	ExecObjectLayerAPITest(ExecObjectLayerAPITestArgs{t: t, objAPITest: testListObjectsNonExistentBucketHandler})
+}
+
+func testListObjectsNonExistentBucketHandler(_ ObjectLayer, instanceType, _ string, apiRouter http.Handler,
+	credentials auth.Credentials, t *testing.T,
+) {
+	const bucket = "missing-bucket"
+	testCases := []struct {
+		name  string
+		query url.Values
+	}{
+		{name: "ListObjects", query: url.Values{"prefix": {"/"}}},
+		{name: "ListObjectsV2", query: url.Values{"list-type": {"2"}, "prefix": {"/"}}},
+		{name: "ListObjectVersions", query: url.Values{"versions": {""}, "prefix": {"/"}}},
+	}
+
+	for _, tc := range testCases {
+		req, err := newTestSignedRequestV4(http.MethodGet, makeTestTargetURL("", bucket, "", tc.query), 0, nil,
+			credentials.AccessKey, credentials.SecretKey, nil)
+		if err != nil {
+			t.Fatalf("%s: %s: failed to create request: %v", instanceType, tc.name, err)
+		}
+		rec := httptest.NewRecorder()
+		apiRouter.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: %s: expected status %d, got %d", instanceType, tc.name, http.StatusNotFound, rec.Code)
+		}
+
+		var apiErr APIErrorResponse
+		if err = xml.Unmarshal(rec.Body.Bytes(), &apiErr); err != nil {
+			t.Fatalf("%s: %s: failed to decode error response: %v", instanceType, tc.name, err)
+		}
+		if apiErr.Code != "NoSuchBucket" {
+			t.Errorf("%s: %s: expected NoSuchBucket, got %q", instanceType, tc.name, apiErr.Code)
+		}
+	}
+}
 
 // Wrapper for calling RemoveBucket HTTP handler tests for both Erasure multiple disks and single node setup.
 func TestRemoveBucketHandler(t *testing.T) {

--- a/cmd/metacache-server-pool.go
+++ b/cmd/metacache-server-pool.go
@@ -71,13 +71,13 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 	if o.Marker != "" && o.Prefix != "" {
 		// Marker not common with prefix is not implemented. Send an empty response
 		if !HasPrefix(o.Marker, o.Prefix) {
-			return entries, io.EOF
+			return entries, z.listPathShortcutEOF(ctx, o.Bucket)
 		}
 	}
 
 	// With max keys of zero we have reached eof, return right here.
 	if o.Limit == 0 {
-		return entries, io.EOF
+		return entries, z.listPathShortcutEOF(ctx, o.Bucket)
 	}
 
 	// For delimiter and prefix as '/' we do not list anything at all
@@ -85,7 +85,7 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 	// as '/' we don't have any entries, since all the keys are
 	// of form 'keyName/...'
 	if strings.HasPrefix(o.Prefix, SlashSeparator) {
-		return entries, io.EOF
+		return entries, z.listPathShortcutEOF(ctx, o.Bucket)
 	}
 
 	// If delimiter is slashSeparator we must return directories of
@@ -252,6 +252,16 @@ func (z *erasureServerPools) listPath(ctx context.Context, o *listPathOptions) (
 		return entries, io.EOF
 	}
 	return entries, nil
+}
+
+// listPathShortcutEOF verifies bucket existence for shortcuts that return
+// without consulting the storage layer. Keep this check out of the normal
+// listing path since GetBucketInfo fans out to peers and disks.
+func (z *erasureServerPools) listPathShortcutEOF(ctx context.Context, bucket string) error {
+	if _, err := z.GetBucketInfo(ctx, bucket, BucketOptions{}); err != nil {
+		return err
+	}
+	return io.EOF
 }
 
 // listMerged will list across all sets and return a merged results stream.

--- a/cmd/object_api_suite_test.go
+++ b/cmd/object_api_suite_test.go
@@ -849,6 +849,45 @@ func testListObjectsTestsForNonExistentBucket(obj ObjectLayer, instanceType stri
 	}
 }
 
+// Wrapper for calling testListObjectsShortcutsForNonExistentBucket for both
+// single-drive and multi-drive erasure setups.
+func TestListObjectsShortcutsForNonExistentBucket(t *testing.T) {
+	ExecObjectLayerTest(t, testListObjectsShortcutsForNonExistentBucket)
+}
+
+// Tests validate that storage-bypassing list shortcuts do not mask a missing
+// bucket as an empty result. The regular prefix case is a control for the
+// storage-backed listing path.
+func testListObjectsShortcutsForNonExistentBucket(obj ObjectLayer, instanceType string, t TestErrHandler) {
+	testCases := []struct {
+		name    string
+		prefix  string
+		marker  string
+		maxKeys int
+	}{
+		{name: "slash-prefixed prefix", prefix: "/", maxKeys: 1000},
+		{name: "zero limit", prefix: "obj", maxKeys: 0},
+		{name: "marker outside prefix", prefix: "a", marker: "b", maxKeys: 1000},
+		{name: "regular prefix", prefix: "foo/bar", maxKeys: 1000},
+	}
+	for _, tc := range testCases {
+		_, err := obj.ListObjects(context.Background(), "bucket", tc.prefix, tc.marker, "", tc.maxKeys)
+		if !isErrBucketNotFound(err) {
+			t.Errorf("%s: ListObjects %s: expected BucketNotFound, got %v", instanceType, tc.name, err)
+		}
+
+		_, err = obj.ListObjectsV2(context.Background(), "bucket", tc.prefix, "", "", tc.maxKeys, false, tc.marker)
+		if !isErrBucketNotFound(err) {
+			t.Errorf("%s: ListObjectsV2 %s: expected BucketNotFound, got %v", instanceType, tc.name, err)
+		}
+
+		_, err = obj.ListObjectVersions(context.Background(), "bucket", tc.prefix, tc.marker, "", "", tc.maxKeys)
+		if !isErrBucketNotFound(err) {
+			t.Errorf("%s: ListObjectVersions %s: expected BucketNotFound, got %v", instanceType, tc.name, err)
+		}
+	}
+}
+
 // Wrapper for calling testNonExistentObjectInBucket for both Erasure and FS.
 func TestNonExistentObjectInBucket(t *testing.T) {
 	ExecObjectLayerTest(t, testNonExistentObjectInBucket)


### PR DESCRIPTION
## Contribution licensing

This maintainer-submitted revision is licensed inbound=outbound under the repository AGPL-3.0-or-later terms and carries a matching DCO sign-off. It preserves Jason Lin as a co-author of the original contribution.

## Problem

`ListObjects` on a missing bucket can return an empty 200 instead of `NoSuchBucket` when `listPath` exits before consulting storage. The affected shortcuts are:

- a prefix beginning with `/`;
- `max-keys=0`;
- a marker outside the requested prefix.

The regression came from upstream `80ca12008` / minio#18917, which removed generic bucket-existence checks to avoid cluster-wide `GetBucketInfo` fan-out. Normal listing still discovers a missing bucket through storage, but these shortcuts never reach that path.

Fixes #32.

## Implementation

Verify bucket existence only immediately before the three storage-bypassing EOF returns. An existing bucket keeps the original empty-list result; a missing bucket reaches the existing 404 `NoSuchBucket` mapping. The normal listing hot path remains unchanged.

This deliberately does not restore the generic existence check or add a cache. `GetBucketInfo` fans out to peers and disks, so only shortcut traffic pays that cost.

## Tests

The updated revision covers `ListObjects`, `ListObjectsV2`, and `ListObjectVersions` for:

- slash-prefixed prefix;
- zero limit;
- marker outside prefix;
- a regular storage-backed prefix as a control.

HTTP tests verify signed V1, V2, and version-list requests return status 404 with XML code `NoSuchBucket`.

Local verification on exact head `e9c5340be`:

- `go test ./cmd -count=1`;
- focused regression and race tests;
- related existing listing tests;
- `CGO_ENABLED=0 go build ./...`;
- `go vet ./...`;
- gofmt and diff checks.

A separate local Claude Code Fable Max adversarial review returned **GO** with no mandatory pre-merge change.

## Compatibility and performance

This restores AWS S3 behavior and the behavior before `80ca12008`. Clients that relied on the incorrect empty 200 will now receive 404. Shortcut calls are more expensive because they perform `GetBucketInfo`; normal listings do not. Large-cluster shortcut frequency and tail latency remain post-merge observability items, not reasons to reintroduce a generic check.

## Checklist

- [x] Fixes a regression (`80ca12008`)
- [x] Unit and HTTP tests added
- [x] DCO sign-off present
- [x] Local build, vet, tests, race, and formatting checks passed
- [x] Design record prepared in `pgsty/silo.pgsty.com`
- [x] Remote CI green on the exact PR head

