### PR TITLE
perl -p -i -e 's/docs.min.io/silo.pigsty.io/g'

### DIFF
--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -177,7 +177,7 @@ func formatGetBackendErasureVersion(b []byte) (string, error) {
 		return "", fmt.Errorf(`format.Version expected: %s, got: %s`, formatMetaVersionV1, meta.Version)
 	}
 	if meta.Format != formatBackendErasure && meta.Format != formatBackendErasureSingle {
-		return "", fmt.Errorf(`found backend type %s, expected %s or %s - to migrate to a supported backend visit https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-migrate-fs-gateway.html`, meta.Format, formatBackendErasure, formatBackendErasureSingle)
+		return "", fmt.Errorf(`found backend type %s, expected %s or %s - to migrate to a supported backend visit https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-migrate-fs-gateway.html`, meta.Format, formatBackendErasure, formatBackendErasureSingle)
 	}
 	// Erasure backend found, proceed to detect version.
 	format := &formatErasureVersionDetect{}

--- a/cmd/format-erasure.go
+++ b/cmd/format-erasure.go
@@ -177,7 +177,7 @@ func formatGetBackendErasureVersion(b []byte) (string, error) {
 		return "", fmt.Errorf(`format.Version expected: %s, got: %s`, formatMetaVersionV1, meta.Version)
 	}
 	if meta.Format != formatBackendErasure && meta.Format != formatBackendErasureSingle {
-		return "", fmt.Errorf(`found backend type %s, expected %s or %s - to migrate to a supported backend visit https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-migrate-fs-gateway.html`, meta.Format, formatBackendErasure, formatBackendErasureSingle)
+		return "", fmt.Errorf(`found backend type %s, expected %s or %s - to migrate to a supported backend visit https://silo.pigsty.io/operations/deployments/baremetal-migrate-fs-gateway.html`, meta.Format, formatBackendErasure, formatBackendErasureSingle)
 	}
 	// Erasure backend found, proceed to detect version.
 	format := &formatErasureVersionDetect{}

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -144,7 +144,7 @@ func printServerCommonMsg(apiEndpoints []string) {
 
 // Prints startup message for Object API access, prints link to our SDK documentation.
 func printObjectAPIMsg() {
-	logger.Startup(color.Blue("\nDocs: ") + "https://docs.min.io")
+	logger.Startup(color.Blue("\nDocs: ") + "https://silo.pigsty.io")
 }
 
 func printLambdaTargets() {
@@ -184,7 +184,7 @@ func printCLIAccessMsg(endPoint string, alias string) {
 	// Get saved credentials.
 	cred := globalActiveCred
 
-	const mcQuickStartGuide = "https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart"
+	const mcQuickStartGuide = "https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart"
 
 	// Configure 'mc', following block prints platform specific information for minio client.
 	if color.IsTerminal() && (!globalServerCtxt.Anonymous && globalAPIConfig.permitRootAccess()) {

--- a/cmd/server-startup-msg.go
+++ b/cmd/server-startup-msg.go
@@ -184,7 +184,7 @@ func printCLIAccessMsg(endPoint string, alias string) {
 	// Get saved credentials.
 	cred := globalActiveCred
 
-	const mcQuickStartGuide = "https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart"
+	const mcQuickStartGuide = "https://silo.pigsty.io/reference/minio-mc.html#quickstart"
 
 	// Configure 'mc', following block prints platform specific information for minio client.
 	if color.IsTerminal() && (!globalServerCtxt.Anonymous && globalAPIConfig.permitRootAccess()) {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -450,10 +450,10 @@ func getLatestReleaseTime(u *url.URL, timeout time.Duration, mode string) (sha25
 
 const (
 	// Kubernetes deployment doc link.
-	kubernetesDeploymentDoc = "https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html"
+	kubernetesDeploymentDoc = "https://silo.pigsty.io/operations/deployments/kubernetes.html"
 
 	// Mesos deployment doc link.
-	mesosDeploymentDoc = "https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html"
+	mesosDeploymentDoc = "https://silo.pigsty.io/operations/deployments/kubernetes.html"
 )
 
 func getDownloadURL(releaseTag string) (downloadURL string) {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -450,10 +450,10 @@ func getLatestReleaseTime(u *url.URL, timeout time.Duration, mode string) (sha25
 
 const (
 	// Kubernetes deployment doc link.
-	kubernetesDeploymentDoc = "https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html"
+	kubernetesDeploymentDoc = "https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html"
 
 	// Mesos deployment doc link.
-	mesosDeploymentDoc = "https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html"
+	mesosDeploymentDoc = "https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html"
 )
 
 func getDownloadURL(releaseTag string) (downloadURL string) {

--- a/docs/bigdata/README.md
+++ b/docs/bigdata/README.md
@@ -16,7 +16,7 @@ MinIO also supports multi-cluster, multi-site federation similar to AWS regions 
   - [Setup Ambari](https://docs.hortonworks.com/HDPDocuments/Ambari-2.7.1.0/bk_ambari-installation/content/set_up_the_ambari_server.html) which automatically sets up YARN
   - [Installing Spark](https://docs.hortonworks.com/HDPDocuments/HDP3/HDP-3.0.1/installing-spark/content/installing_spark.html)
 - Install MinIO Distributed Server using one of the guides below.
-  - [Deployment based on Kubernetes](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html)
+  - [Deployment based on Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html)
   - [Deployment based on MinIO Helm Chart](https://github.com/helm/charts/tree/master/stable/minio)
 
 ## **3. Configure Hadoop, Spark, Hive to use MinIO**

--- a/docs/bigdata/README.md
+++ b/docs/bigdata/README.md
@@ -16,7 +16,7 @@ MinIO also supports multi-cluster, multi-site federation similar to AWS regions 
   - [Setup Ambari](https://docs.hortonworks.com/HDPDocuments/Ambari-2.7.1.0/bk_ambari-installation/content/set_up_the_ambari_server.html) which automatically sets up YARN
   - [Installing Spark](https://docs.hortonworks.com/HDPDocuments/HDP3/HDP-3.0.1/installing-spark/content/installing_spark.html)
 - Install MinIO Distributed Server using one of the guides below.
-  - [Deployment based on Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html)
+  - [Deployment based on Kubernetes](https://silo.pigsty.io/operations/deployments/kubernetes.html)
   - [Deployment based on MinIO Helm Chart](https://github.com/helm/charts/tree/master/stable/minio)
 
 ## **3. Configure Hadoop, Spark, Hive to use MinIO**

--- a/docs/bucket/lifecycle/DESIGN.md
+++ b/docs/bucket/lifecycle/DESIGN.md
@@ -51,5 +51,5 @@ Tiering and lifecycle transition are applicable only to erasure/distributed MinI
 
 ## Explore Further
 
-- [MinIO | Golang Client API Reference](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#SetBucketLifecycle)
+- [MinIO | Golang Client API Reference](https://silo.pigsty.io/developers/go/API.html#SetBucketLifecycle)
 - [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html)

--- a/docs/bucket/lifecycle/DESIGN.md
+++ b/docs/bucket/lifecycle/DESIGN.md
@@ -51,5 +51,5 @@ Tiering and lifecycle transition are applicable only to erasure/distributed MinI
 
 ## Explore Further
 
-- [MinIO | Golang Client API Reference](https://docs.min.io/community/minio-object-store/developers/go/API.html#SetBucketLifecycle)
+- [MinIO | Golang Client API Reference](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#SetBucketLifecycle)
 - [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html)

--- a/docs/bucket/lifecycle/README.md
+++ b/docs/bucket/lifecycle/README.md
@@ -4,8 +4,8 @@ Enable object lifecycle configuration on buckets to setup automatic deletion of 
 
 ## 1. Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
-- Install `mc` - [mc Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+- Install `mc` - [mc Quickstart Guide](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
 
 ## 2. Enable bucket lifecycle configuration
 
@@ -59,7 +59,7 @@ TempUploads |  temp/   |    ✓       |  ✓     |   7 day(s)   |     ✗       
 
 ## 3. Activate ILM versioning features
 
-This will only work with a versioned bucket, take a look at [Bucket Versioning Guide](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html) for more understanding.
+This will only work with a versioned bucket, take a look at [Bucket Versioning Guide](https://silo.pigsty.io/administration/object-management/object-versioning.html) for more understanding.
 
 ### 3.1 Automatic removal of non current objects versions
 
@@ -228,5 +228,5 @@ Note that transition event notification is a MinIO extension.
 
 ## Explore Further
 
-- [MinIO | Golang Client API Reference](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html)
+- [MinIO | Golang Client API Reference](https://silo.pigsty.io/developers/go/API.html)
 - [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html)

--- a/docs/bucket/lifecycle/README.md
+++ b/docs/bucket/lifecycle/README.md
@@ -4,8 +4,8 @@ Enable object lifecycle configuration on buckets to setup automatic deletion of 
 
 ## 1. Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
-- Install `mc` - [mc Quickstart Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+- Install `mc` - [mc Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
 
 ## 2. Enable bucket lifecycle configuration
 
@@ -59,7 +59,7 @@ TempUploads |  temp/   |    ✓       |  ✓     |   7 day(s)   |     ✗       
 
 ## 3. Activate ILM versioning features
 
-This will only work with a versioned bucket, take a look at [Bucket Versioning Guide](https://docs.min.io/community/minio-object-store/administration/object-management/object-versioning.html) for more understanding.
+This will only work with a versioned bucket, take a look at [Bucket Versioning Guide](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html) for more understanding.
 
 ### 3.1 Automatic removal of non current objects versions
 
@@ -228,5 +228,5 @@ Note that transition event notification is a MinIO extension.
 
 ## Explore Further
 
-- [MinIO | Golang Client API Reference](https://docs.min.io/community/minio-object-store/developers/go/API.html)
+- [MinIO | Golang Client API Reference](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html)
 - [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html)

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -30,7 +30,7 @@ Various event types supported by MinIO server are
 | `s3:BucketCreated`                                                           |
 | `s3:BucketRemoved`                                                           |
 
-Use client tools like `mc` to set and listen for event notifications using the [`event` sub-command](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-event-add.html). MinIO SDK's [`BucketNotification` APIs](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#setbucketnotification-ctx-context-context-bucketname-string-config-notification-configuration-error) can also be used. The notification message MinIO sends to publish an event is a JSON message with the following [structure](https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html).
+Use client tools like `mc` to set and listen for event notifications using the [`event` sub-command](https://silo.pigsty.io/reference/minio-mc/mc-event-add.html). MinIO SDK's [`BucketNotification` APIs](https://silo.pigsty.io/developers/go/API.html#setbucketnotification-ctx-context-context-bucketname-string-config-notification-configuration-error) can also be used. The notification message MinIO sends to publish an event is a JSON message with the following [structure](https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html).
 
 Bucket events can be published to the following targets:
 
@@ -43,8 +43,8 @@ Bucket events can be published to the following targets:
 
 ## Prerequisites
 
-- Install and configure MinIO Server from [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
-- Install and configure MinIO Client from [here](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart).
+- Install and configure MinIO Server from [here](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- Install and configure MinIO Client from [here](https://silo.pigsty.io/reference/minio-mc.html#quickstart).
 
 ```
 $ mc admin config get myminio | grep notify

--- a/docs/bucket/notifications/README.md
+++ b/docs/bucket/notifications/README.md
@@ -30,7 +30,7 @@ Various event types supported by MinIO server are
 | `s3:BucketCreated`                                                           |
 | `s3:BucketRemoved`                                                           |
 
-Use client tools like `mc` to set and listen for event notifications using the [`event` sub-command](https://docs.min.io/community/minio-object-store/reference/minio-mc/mc-event-add.html). MinIO SDK's [`BucketNotification` APIs](https://docs.min.io/community/minio-object-store/developers/go/API.html#setbucketnotification-ctx-context-context-bucketname-string-config-notification-configuration-error) can also be used. The notification message MinIO sends to publish an event is a JSON message with the following [structure](https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html).
+Use client tools like `mc` to set and listen for event notifications using the [`event` sub-command](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-event-add.html). MinIO SDK's [`BucketNotification` APIs](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#setbucketnotification-ctx-context-context-bucketname-string-config-notification-configuration-error) can also be used. The notification message MinIO sends to publish an event is a JSON message with the following [structure](https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html).
 
 Bucket events can be published to the following targets:
 
@@ -43,8 +43,8 @@ Bucket events can be published to the following targets:
 
 ## Prerequisites
 
-- Install and configure MinIO Server from [here](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
-- Install and configure MinIO Client from [here](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart).
+- Install and configure MinIO Server from [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- Install and configure MinIO Client from [here](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart).
 
 ```
 $ mc admin config get myminio | grep notify

--- a/docs/bucket/quota/README.md
+++ b/docs/bucket/quota/README.md
@@ -6,8 +6,8 @@ Buckets can be configured to have `Hard` quota - it disallows writes to the buck
 
 ## Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
 
 ## Set bucket quota configuration
 

--- a/docs/bucket/quota/README.md
+++ b/docs/bucket/quota/README.md
@@ -6,8 +6,8 @@ Buckets can be configured to have `Hard` quota - it disallows writes to the buck
 
 ## Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
 
 ## Set bucket quota configuration
 

--- a/docs/bucket/replication/DESIGN.md
+++ b/docs/bucket/replication/DESIGN.md
@@ -156,5 +156,5 @@ If 3 or more targets are participating in active-active replication, the replica
 
 ## Explore Further
 
-- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html)
-- [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/administration/object-management/object-versioning.html)
+- [MinIO Client Quickstart Guide](https://silo.pigsty.io/reference/minio-mc.html#quickstart)

--- a/docs/bucket/replication/DESIGN.md
+++ b/docs/bucket/replication/DESIGN.md
@@ -156,5 +156,5 @@ If 3 or more targets are participating in active-active replication, the replica
 
 ## Explore Further
 
-- [MinIO Bucket Versioning Implementation](https://docs.min.io/community/minio-object-store/administration/object-management/object-versioning.html)
-- [MinIO Client Quickstart Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html)
+- [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -2,9 +2,9 @@
 
 Bucket replication is designed to replicate selected objects in a bucket to a destination bucket.
 
-The contents of this page have been migrated to the new [MinIO Documentation: Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) page. The [Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication/bucket-replication-requirements.html) page references dedicated tutorials for configuring one-way "Active-Passive" and two-way "Active-Active" bucket replication.
+The contents of this page have been migrated to the new [MinIO Documentation: Bucket Replication](https://silo.pigsty.io/administration/bucket-replication.html) page. The [Bucket Replication](https://silo.pigsty.io/administration/bucket-replication/bucket-replication-requirements.html) page references dedicated tutorials for configuring one-way "Active-Passive" and two-way "Active-Active" bucket replication.
 
-To replicate objects in a bucket to a destination bucket on a target site either in the same cluster or a different cluster, start by enabling [versioning](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html) for both source and destination buckets. Finally, the target site and the destination bucket need to be configured on the source MinIO server.
+To replicate objects in a bucket to a destination bucket on a target site either in the same cluster or a different cluster, start by enabling [versioning](https://silo.pigsty.io/administration/object-management/object-versioning.html) for both source and destination buckets. Finally, the target site and the destination bucket need to be configured on the source MinIO server.
 
 ## Highlights
 
@@ -155,7 +155,7 @@ The replication configuration generated has the following format and can be expo
 
 The replication configuration follows [AWS S3 Spec](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html). Any objects uploaded to the source bucket that meet replication criteria will now be automatically replicated by the MinIO server to the remote destination bucket. Replication can be disabled at any time by disabling specific rules in the configuration or deleting the replication configuration entirely.
 
-When object locking is used in conjunction with replication, both source and destination buckets needs to have [object locking](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html) enabled. Similarly objects encrypted on the server side, will be replicated if destination also supports encryption.
+When object locking is used in conjunction with replication, both source and destination buckets needs to have [object locking](https://silo.pigsty.io/administration/object-management/object-retention.html) enabled. Similarly objects encrypted on the server side, will be replicated if destination also supports encryption.
 
 Replication status can be seen in the metadata on the source and destination objects. On the source side, the `X-Amz-Replication-Status` changes from `PENDING` to `COMPLETED` or `FAILED` after replication attempt either succeeded or failed respectively. On the destination side, a `X-Amz-Replication-Status` status of `REPLICA` indicates that the object was replicated successfully. Any replication failures are automatically re-attempted during a periodic disk scanner cycle.
 
@@ -277,5 +277,5 @@ MinIO does not support SSE-C encrypted objects on replicated buckets, any applic
 ## Explore Further
 
 - [MinIO Bucket Replication Design](https://github.com/pgsty/minio/blob/master/docs/bucket/replication/DESIGN.md)
-- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html)
-- [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/administration/object-management/object-retention.html)
+- [MinIO Client Quickstart Guide](https://silo.pigsty.io/reference/minio-mc.html#quickstart)

--- a/docs/bucket/replication/README.md
+++ b/docs/bucket/replication/README.md
@@ -2,9 +2,9 @@
 
 Bucket replication is designed to replicate selected objects in a bucket to a destination bucket.
 
-The contents of this page have been migrated to the new [MinIO Documentation: Bucket Replication](https://docs.min.io/community/minio-object-store/administration/bucket-replication.html) page. The [Bucket Replication](https://docs.min.io/community/minio-object-store/administration/bucket-replication/bucket-replication-requirements.html) page references dedicated tutorials for configuring one-way "Active-Passive" and two-way "Active-Active" bucket replication.
+The contents of this page have been migrated to the new [MinIO Documentation: Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) page. The [Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication/bucket-replication-requirements.html) page references dedicated tutorials for configuring one-way "Active-Passive" and two-way "Active-Active" bucket replication.
 
-To replicate objects in a bucket to a destination bucket on a target site either in the same cluster or a different cluster, start by enabling [versioning](https://docs.min.io/community/minio-object-store/administration/object-management/object-versioning.html) for both source and destination buckets. Finally, the target site and the destination bucket need to be configured on the source MinIO server.
+To replicate objects in a bucket to a destination bucket on a target site either in the same cluster or a different cluster, start by enabling [versioning](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-versioning.html) for both source and destination buckets. Finally, the target site and the destination bucket need to be configured on the source MinIO server.
 
 ## Highlights
 
@@ -155,7 +155,7 @@ The replication configuration generated has the following format and can be expo
 
 The replication configuration follows [AWS S3 Spec](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html). Any objects uploaded to the source bucket that meet replication criteria will now be automatically replicated by the MinIO server to the remote destination bucket. Replication can be disabled at any time by disabling specific rules in the configuration or deleting the replication configuration entirely.
 
-When object locking is used in conjunction with replication, both source and destination buckets needs to have [object locking](https://docs.min.io/community/minio-object-store/administration/object-management/object-retention.html) enabled. Similarly objects encrypted on the server side, will be replicated if destination also supports encryption.
+When object locking is used in conjunction with replication, both source and destination buckets needs to have [object locking](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html) enabled. Similarly objects encrypted on the server side, will be replicated if destination also supports encryption.
 
 Replication status can be seen in the metadata on the source and destination objects. On the source side, the `X-Amz-Replication-Status` changes from `PENDING` to `COMPLETED` or `FAILED` after replication attempt either succeeded or failed respectively. On the destination side, a `X-Amz-Replication-Status` status of `REPLICA` indicates that the object was replicated successfully. Any replication failures are automatically re-attempted during a periodic disk scanner cycle.
 
@@ -277,5 +277,5 @@ MinIO does not support SSE-C encrypted objects on replicated buckets, any applic
 ## Explore Further
 
 - [MinIO Bucket Replication Design](https://github.com/pgsty/minio/blob/master/docs/bucket/replication/DESIGN.md)
-- [MinIO Bucket Versioning Implementation](https://docs.min.io/community/minio-object-store/administration/object-management/object-retention.html)
-- [MinIO Client Quickstart Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- [MinIO Bucket Versioning Implementation](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html)
+- [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)

--- a/docs/bucket/retention/README.md
+++ b/docs/bucket/retention/README.md
@@ -10,7 +10,7 @@ A default retention period and retention mode can be configured on a bucket to b
 
 ### 1. Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 - Install `awscli` - [Installing AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 
 ### 2. Set bucket WORM configuration
@@ -53,7 +53,7 @@ See <https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html> 
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/bucket/retention/README.md
+++ b/docs/bucket/retention/README.md
@@ -10,7 +10,7 @@ A default retention period and retention mode can be configured on a bucket to b
 
 ### 1. Prerequisites
 
-- Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 - Install `awscli` - [Installing AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 
 ### 2. Set bucket WORM configuration
@@ -53,7 +53,7 @@ See <https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html> 
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -211,7 +211,7 @@ public class IsVersioningEnabled {
 
 ## Explore Further
 
-- [Use `minio-java` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/java/minio-java.html)
-- [Object Lock and Immutability Guide](https://docs.min.io/community/minio-object-store/administration/object-management/object-retention.html)
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `minio-java` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/java/minio-java.html)
+- [Object Lock and Immutability Guide](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/bucket/versioning/README.md
+++ b/docs/bucket/versioning/README.md
@@ -211,7 +211,7 @@ public class IsVersioningEnabled {
 
 ## Explore Further
 
-- [Use `minio-java` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/java/minio-java.html)
-- [Object Lock and Immutability Guide](https://silo.pigsty.io/community/minio-object-store/administration/object-management/object-retention.html)
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `minio-java` SDK with MinIO Server](https://silo.pigsty.io/developers/java/minio-java.html)
+- [Object Lock and Immutability Guide](https://silo.pigsty.io/administration/object-management/object-retention.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/chroot/README.md
+++ b/docs/chroot/README.md
@@ -51,8 +51,8 @@ Instance is now accessible on the host at port 9000, proceed to access the Web b
 
 ## Explore Further
 
-- [MinIO Erasure Code Overview](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Erasure Code Overview](https://silo.pigsty.io/operations/concepts/erasure-coding.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/chroot/README.md
+++ b/docs/chroot/README.md
@@ -51,8 +51,8 @@ Instance is now accessible on the host at port 9000, proceed to access the Web b
 
 ## Explore Further
 
-- [MinIO Erasure Code Overview](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html)
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Erasure Code Overview](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/compression/README.md
+++ b/docs/compression/README.md
@@ -19,7 +19,7 @@ will increase speed when the content can be compressed.
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ### 2. Run MinIO with compression
 
@@ -131,7 +131,7 @@ the data directory to view the size of the object.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/compression/README.md
+++ b/docs/compression/README.md
@@ -19,7 +19,7 @@ will increase speed when the content can be compressed.
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ### 2. Run MinIO with compression
 
@@ -131,7 +131,7 @@ the data directory to view the size of the object.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -6,7 +6,7 @@ MinIO stores all its config as part of the server deployment, config is erasure 
 
 ### Certificate Directory
 
-TLS certificates by default are expected to be stored under ``${HOME}/.minio/certs`` directory. You need to place certificates here to enable `HTTPS` based access. Read more about [How to secure access to MinIO server with TLS](https://docs.min.io/community/minio-object-store/operations/network-encryption.html).
+TLS certificates by default are expected to be stored under ``${HOME}/.minio/certs`` directory. You need to place certificates here to enable `HTTPS` based access. Read more about [How to secure access to MinIO server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
 
 Following is a sample directory structure for MinIO server with TLS certificates.
 
@@ -172,7 +172,7 @@ MINIO_API_OBJECT_MAX_VERSIONS             (number)    set max allowed number of 
 
 #### Notifications
 
-Notification targets supported by MinIO are in the following list. To configure individual targets please refer to more detailed documentation [here](https://docs.min.io/community/minio-object-store/administration/monitoring.html#bucket-notifications).
+Notification targets supported by MinIO are in the following list. To configure individual targets please refer to more detailed documentation [here](https://silo.pigsty.io/community/minio-object-store/administration/monitoring.html#bucket-notifications).
 
 ```
 notify_webhook        publish bucket notifications to webhook endpoints
@@ -336,5 +336,5 @@ minio server /data
 
 ## Explore Further
 
-* [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
-* [Configure MinIO Server with TLS](https://docs.min.io/community/minio-object-store/operations/network-encryption.html)
+* [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+* [Configure MinIO Server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -6,7 +6,7 @@ MinIO stores all its config as part of the server deployment, config is erasure 
 
 ### Certificate Directory
 
-TLS certificates by default are expected to be stored under ``${HOME}/.minio/certs`` directory. You need to place certificates here to enable `HTTPS` based access. Read more about [How to secure access to MinIO server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
+TLS certificates by default are expected to be stored under ``${HOME}/.minio/certs`` directory. You need to place certificates here to enable `HTTPS` based access. Read more about [How to secure access to MinIO server with TLS](https://silo.pigsty.io/operations/network-encryption.html).
 
 Following is a sample directory structure for MinIO server with TLS certificates.
 
@@ -172,7 +172,7 @@ MINIO_API_OBJECT_MAX_VERSIONS             (number)    set max allowed number of 
 
 #### Notifications
 
-Notification targets supported by MinIO are in the following list. To configure individual targets please refer to more detailed documentation [here](https://silo.pigsty.io/community/minio-object-store/administration/monitoring.html#bucket-notifications).
+Notification targets supported by MinIO are in the following list. To configure individual targets please refer to more detailed documentation [here](https://silo.pigsty.io/administration/monitoring.html#bucket-notifications).
 
 ```
 notify_webhook        publish bucket notifications to webhook endpoints
@@ -336,5 +336,5 @@ minio server /data
 
 ## Explore Further
 
-* [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
-* [Configure MinIO Server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
+* [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+* [Configure MinIO Server with TLS](https://silo.pigsty.io/operations/network-encryption.html)

--- a/docs/debugging/README.md
+++ b/docs/debugging/README.md
@@ -2,7 +2,7 @@
 
 ## HTTP Trace
 
-HTTP tracing can be enabled by using [`mc admin trace`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-trace.html) command.
+HTTP tracing can be enabled by using [`mc admin trace`](https://silo.pigsty.io/reference/minio-mc-admin/mc-admin-trace.html) command.
 
 Example:
 

--- a/docs/debugging/README.md
+++ b/docs/debugging/README.md
@@ -2,7 +2,7 @@
 
 ## HTTP Trace
 
-HTTP tracing can be enabled by using [`mc admin trace`](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-trace.html) command.
+HTTP tracing can be enabled by using [`mc admin trace`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-trace.html) command.
 
 Example:
 

--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -8,7 +8,7 @@ MinIO in distributed mode can help you setup a highly-available storage system w
 
 ### Data protection
 
-Distributed MinIO provides protection against multiple node/drive failures and [bit rot](https://github.com/pgsty/minio/blob/master/docs/erasure/README.md#what-is-bit-rot-protection) using [erasure code](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html). As the minimum drives required for distributed MinIO is 2 (same as minimum drives required for erasure coding), erasure code automatically kicks in as you launch distributed MinIO.
+Distributed MinIO provides protection against multiple node/drive failures and [bit rot](https://github.com/pgsty/minio/blob/master/docs/erasure/README.md#what-is-bit-rot-protection) using [erasure code](https://silo.pigsty.io/operations/concepts/erasure-coding.html). As the minimum drives required for distributed MinIO is 2 (same as minimum drives required for erasure coding), erasure code automatically kicks in as you launch distributed MinIO.
 
 If one or more drives are offline at the start of a PutObject or NewMultipartUpload operation the object will have additional data protection bits added automatically to provide additional safety for these objects.
 
@@ -38,11 +38,11 @@ Install MinIO either on Kubernetes or Distributed Linux.
 
 Install MinIO on Kubernetes:
 
-- [MinIO Quickstart Guide for Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html).
-- [Deploy a Tenant from the MinIO Operator](https://silo.pigsty.io/community/minio-object-store/operations/deployments/k8s-deploy-minio-tenant-on-kubernetes.html)
+- [MinIO Quickstart Guide for Kubernetes](https://silo.pigsty.io/operations/deployments/kubernetes.html).
+- [Deploy a Tenant from the MinIO Operator](https://silo.pigsty.io/operations/deployments/k8s-deploy-minio-tenant-on-kubernetes.html)
 
 Install Distributed MinIO on Linux:
-- [Deploy Distributed MinIO on Linux](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#deploy-distributed-minio)
+- [Deploy Distributed MinIO on Linux](https://silo.pigsty.io/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#deploy-distributed-minio)
 
 ### 2. Run distributed MinIO
 
@@ -98,12 +98,12 @@ Now the server has expanded total storage by _(newly_added_servers\*m)_ more dri
 
 ## 3. Test your setup
 
-To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart).
+To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/reference/minio-mc.html#quickstart).
 
 ## Explore Further
 
-- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/operations/concepts/erasure-coding.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/distributed/README.md
+++ b/docs/distributed/README.md
@@ -8,7 +8,7 @@ MinIO in distributed mode can help you setup a highly-available storage system w
 
 ### Data protection
 
-Distributed MinIO provides protection against multiple node/drive failures and [bit rot](https://github.com/pgsty/minio/blob/master/docs/erasure/README.md#what-is-bit-rot-protection) using [erasure code](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html). As the minimum drives required for distributed MinIO is 2 (same as minimum drives required for erasure coding), erasure code automatically kicks in as you launch distributed MinIO.
+Distributed MinIO provides protection against multiple node/drive failures and [bit rot](https://github.com/pgsty/minio/blob/master/docs/erasure/README.md#what-is-bit-rot-protection) using [erasure code](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html). As the minimum drives required for distributed MinIO is 2 (same as minimum drives required for erasure coding), erasure code automatically kicks in as you launch distributed MinIO.
 
 If one or more drives are offline at the start of a PutObject or NewMultipartUpload operation the object will have additional data protection bits added automatically to provide additional safety for these objects.
 
@@ -38,11 +38,11 @@ Install MinIO either on Kubernetes or Distributed Linux.
 
 Install MinIO on Kubernetes:
 
-- [MinIO Quickstart Guide for Kubernetes](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html).
-- [Deploy a Tenant from the MinIO Operator](https://docs.min.io/community/minio-object-store/operations/deployments/k8s-deploy-minio-tenant-on-kubernetes.html)
+- [MinIO Quickstart Guide for Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html).
+- [Deploy a Tenant from the MinIO Operator](https://silo.pigsty.io/community/minio-object-store/operations/deployments/k8s-deploy-minio-tenant-on-kubernetes.html)
 
 Install Distributed MinIO on Linux:
-- [Deploy Distributed MinIO on Linux](https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#deploy-distributed-minio)
+- [Deploy Distributed MinIO on Linux](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html#deploy-distributed-minio)
 
 ### 2. Run distributed MinIO
 
@@ -98,12 +98,12 @@ Now the server has expanded total storage by _(newly_added_servers\*m)_ more dri
 
 ## 3. Test your setup
 
-To test this setup, access the MinIO server via browser or [`mc`](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart).
+To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart).
 
 ## Explore Further
 
-- [MinIO Erasure Code QuickStart Guide](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html)
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -10,7 +10,7 @@ Docker installed on your machine. Download the relevant installer from [here](ht
 
 ## Run Standalone MinIO on Docker
 
-*Note*: Standalone MinIO is intended for early development and evaluation. For production clusters, deploy a [Distributed](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html) MinIO deployment.
+*Note*: Standalone MinIO is intended for early development and evaluation. For production clusters, deploy a [Distributed](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html) MinIO deployment.
 
 MinIO needs a persistent volume to store configuration and application data. For testing purposes, you can launch MinIO by simply passing a directory (`/data` in the example below). This directory gets created in the container filesystem at the time of container start. But all the data is lost after container exits.
 
@@ -59,7 +59,7 @@ docker run \
 
 We recommend kubernetes based deployment for production level deployment <https://github.com/minio/operator>.
 
-See the [Kubernetes documentation](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html) for more information.
+See the [Kubernetes documentation](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html) for more information.
 
 ## MinIO Docker Tips
 
@@ -213,5 +213,5 @@ docker stats <container_id>
 
 ## Explore Further
 
-* [MinIO in a Container Installation Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
-* [MinIO Erasure Code QuickStart Guide](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+* [MinIO in a Container Installation Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
+* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -10,7 +10,7 @@ Docker installed on your machine. Download the relevant installer from [here](ht
 
 ## Run Standalone MinIO on Docker
 
-*Note*: Standalone MinIO is intended for early development and evaluation. For production clusters, deploy a [Distributed](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html) MinIO deployment.
+*Note*: Standalone MinIO is intended for early development and evaluation. For production clusters, deploy a [Distributed](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-as-a-container.html) MinIO deployment.
 
 MinIO needs a persistent volume to store configuration and application data. For testing purposes, you can launch MinIO by simply passing a directory (`/data` in the example below). This directory gets created in the container filesystem at the time of container start. But all the data is lost after container exits.
 
@@ -59,7 +59,7 @@ docker run \
 
 We recommend kubernetes based deployment for production level deployment <https://github.com/minio/operator>.
 
-See the [Kubernetes documentation](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html) for more information.
+See the [Kubernetes documentation](https://silo.pigsty.io/operations/deployments/kubernetes.html) for more information.
 
 ## MinIO Docker Tips
 
@@ -213,5 +213,5 @@ docker stats <container_id>
 
 ## Explore Further
 
-* [MinIO in a Container Installation Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
-* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+* [MinIO in a Container Installation Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-as-a-container.html)
+* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/operations/concepts/erasure-coding.html)

--- a/docs/erasure/README.md
+++ b/docs/erasure/README.md
@@ -26,7 +26,7 @@ MinIO's erasure coded backend uses high speed [HighwayHash](https://github.com/m
 
 MinIO divides the drives you provide into erasure-coding sets of *2 to 16* drives.  Therefore, the number of drives you present must be a multiple of one of these numbers.  Each object is written to a single erasure-coding set.
 
-Minio uses the largest possible EC set size which divides into the number of drives given. For example, *18 drives* are configured as *2 sets of 9 drives*, and *24 drives* are configured as *2 sets of 12 drives*.  This is true for scenarios when running MinIO as a standalone erasure coded deployment. In [distributed setup however node (affinity) based](https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html) erasure stripe sizes are chosen.
+Minio uses the largest possible EC set size which divides into the number of drives given. For example, *18 drives* are configured as *2 sets of 9 drives*, and *24 drives* are configured as *2 sets of 12 drives*.  This is true for scenarios when running MinIO as a standalone erasure coded deployment. In [distributed setup however node (affinity) based](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html) erasure stripe sizes are chosen.
 
 The drives should all be of approximately the same size.
 
@@ -34,7 +34,7 @@ The drives should all be of approximately the same size.
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 
 ### 2. Run MinIO Server with Erasure Code
 

--- a/docs/erasure/README.md
+++ b/docs/erasure/README.md
@@ -26,7 +26,7 @@ MinIO's erasure coded backend uses high speed [HighwayHash](https://github.com/m
 
 MinIO divides the drives you provide into erasure-coding sets of *2 to 16* drives.  Therefore, the number of drives you present must be a multiple of one of these numbers.  Each object is written to a single erasure-coding set.
 
-Minio uses the largest possible EC set size which divides into the number of drives given. For example, *18 drives* are configured as *2 sets of 9 drives*, and *24 drives* are configured as *2 sets of 12 drives*.  This is true for scenarios when running MinIO as a standalone erasure coded deployment. In [distributed setup however node (affinity) based](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html) erasure stripe sizes are chosen.
+Minio uses the largest possible EC set size which divides into the number of drives given. For example, *18 drives* are configured as *2 sets of 9 drives*, and *24 drives* are configured as *2 sets of 12 drives*.  This is true for scenarios when running MinIO as a standalone erasure coded deployment. In [distributed setup however node (affinity) based](https://silo.pigsty.io/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html) erasure stripe sizes are chosen.
 
 The drives should all be of approximately the same size.
 
@@ -34,7 +34,7 @@ The drives should all be of approximately the same size.
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 
 ### 2. Run MinIO Server with Erasure Code
 

--- a/docs/erasure/storage-class/README.md
+++ b/docs/erasure/storage-class/README.md
@@ -2,7 +2,7 @@
 
 MinIO server supports storage class in erasure coding mode. This allows configurable data and parity drives per object.
 
-This page is intended as a summary of MinIO Erasure Coding. For a more complete explanation, see <https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
+This page is intended as a summary of MinIO Erasure Coding. For a more complete explanation, see <https://silo.pigsty.io/operations/concepts/erasure-coding.html>.
 
 ## Overview
 
@@ -53,7 +53,7 @@ The default value for the `STANDARD` storage class depends on the number of volu
 | 6-7              |                 EC:3  |
 | 8 or more        |                 EC:4  |
 
-For more complete documentation on Erasure Set sizing, see the [MinIO Documentation on Erasure Sets](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html#erasure-sets).
+For more complete documentation on Erasure Set sizing, see the [MinIO Documentation on Erasure Sets](https://silo.pigsty.io/operations/concepts/erasure-coding.html#erasure-sets).
 
 ### Allowed values for REDUCED_REDUNDANCY storage class
 

--- a/docs/erasure/storage-class/README.md
+++ b/docs/erasure/storage-class/README.md
@@ -2,7 +2,7 @@
 
 MinIO server supports storage class in erasure coding mode. This allows configurable data and parity drives per object.
 
-This page is intended as a summary of MinIO Erasure Coding. For a more complete explanation, see <https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
+This page is intended as a summary of MinIO Erasure Coding. For a more complete explanation, see <https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
 
 ## Overview
 
@@ -53,7 +53,7 @@ The default value for the `STANDARD` storage class depends on the number of volu
 | 6-7              |                 EC:3  |
 | 8 or more        |                 EC:4  |
 
-For more complete documentation on Erasure Set sizing, see the [MinIO Documentation on Erasure Sets](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html#erasure-sets).
+For more complete documentation on Erasure Set sizing, see the [MinIO Documentation on Erasure Sets](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html#erasure-sets).
 
 ### Allowed values for REDUCED_REDUNDANCY storage class
 

--- a/docs/federation/lookup/README.md
+++ b/docs/federation/lookup/README.md
@@ -6,7 +6,7 @@ This document explains how to configure MinIO with `Bucket lookup from DNS` styl
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ### 2. Run MinIO in federated mode
 
@@ -76,11 +76,11 @@ it is randomized which cluster might provision the bucket.
 
 ### 3. Test your setup
 
-To test this setup, access the MinIO server via browser or [`mc`](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart). You’ll see the uploaded files are accessible from the all the MinIO endpoints.
+To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart). You’ll see the uploaded files are accessible from the all the MinIO endpoints.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/federation/lookup/README.md
+++ b/docs/federation/lookup/README.md
@@ -6,7 +6,7 @@ This document explains how to configure MinIO with `Bucket lookup from DNS` styl
 
 ### 1. Prerequisites
 
-Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ### 2. Run MinIO in federated mode
 
@@ -76,11 +76,11 @@ it is randomized which cluster might provision the bucket.
 
 ### 3. Test your setup
 
-To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart). You’ll see the uploaded files are accessible from the all the MinIO endpoints.
+To test this setup, access the MinIO server via browser or [`mc`](https://silo.pigsty.io/reference/minio-mc.html#quickstart). You’ll see the uploaded files are accessible from the all the MinIO endpoints.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/integrations/veeam/README.md
+++ b/docs/integrations/veeam/README.md
@@ -5,10 +5,10 @@ When using Veeam Backup and Replication, you can use S3 compatible object storag
 ## Prerequisites
 
 - One or both of Veeam Backup and Replication with support for S3 compatible object store (e.g. 9.5.4) and Veeam Backup for Office365 (VBO)
-- MinIO object storage set up per <https://docs.min.io/community/minio-object-store/index.html>
-- Veeam requires TLS connections to the object storage.  This can be configured per <https://docs.min.io/community/minio-object-store/operations/network-encryption.html>
+- MinIO object storage set up per <https://silo.pigsty.io/community/minio-object-store/index.html>
+- Veeam requires TLS connections to the object storage.  This can be configured per <https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html>
 - The S3 bucket, Access Key and Secret Key have to be created before and outside of Veeam.
-- Configure the minio client for the Veeam MinIO endpoint - <https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html>
+- Configure the minio client for the Veeam MinIO endpoint - <https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html>
 
 ## Setting up an S3 compatible object store for Veeam Backup and Replication
 
@@ -26,7 +26,7 @@ mc mb myminio/veeambackup
 mc mb -l myminio/veeambackup
 ```
 
-> Object locking requires erasure coding enabled on the minio server. For more information see <https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
+> Object locking requires erasure coding enabled on the minio server. For more information see <https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
 
 ### Add MinIO as an object store for Veeam
 

--- a/docs/integrations/veeam/README.md
+++ b/docs/integrations/veeam/README.md
@@ -5,10 +5,10 @@ When using Veeam Backup and Replication, you can use S3 compatible object storag
 ## Prerequisites
 
 - One or both of Veeam Backup and Replication with support for S3 compatible object store (e.g. 9.5.4) and Veeam Backup for Office365 (VBO)
-- MinIO object storage set up per <https://silo.pigsty.io/community/minio-object-store/index.html>
-- Veeam requires TLS connections to the object storage.  This can be configured per <https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html>
+- MinIO object storage set up per <https://silo.pigsty.io/index.html>
+- Veeam requires TLS connections to the object storage.  This can be configured per <https://silo.pigsty.io/operations/network-encryption.html>
 - The S3 bucket, Access Key and Secret Key have to be created before and outside of Veeam.
-- Configure the minio client for the Veeam MinIO endpoint - <https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html>
+- Configure the minio client for the Veeam MinIO endpoint - <https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html>
 
 ## Setting up an S3 compatible object store for Veeam Backup and Replication
 
@@ -26,7 +26,7 @@ mc mb myminio/veeambackup
 mc mb -l myminio/veeambackup
 ```
 
-> Object locking requires erasure coding enabled on the minio server. For more information see <https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html>.
+> Object locking requires erasure coding enabled on the minio server. For more information see <https://silo.pigsty.io/operations/concepts/erasure-coding.html>.
 
 ### Add MinIO as an object store for Veeam
 

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -4,7 +4,7 @@ MinIO uses a key-management-system (KMS) to support SSE-S3. If a client requests
 
 ## Quick Start
 
-MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you haven't installed MinIO, yet, then follow the MinIO [install instructions](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html) first.
+MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you haven't installed MinIO, yet, then follow the MinIO [install instructions](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html) first.
 
 ### 1. Fetch the root identity
 
@@ -67,7 +67,7 @@ The MinIO-KES configuration is always the same - regardless of the underlying KM
 
 ### Further references
 
-- [Run MinIO with TLS / HTTPS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
+- [Run MinIO with TLS / HTTPS](https://silo.pigsty.io/operations/network-encryption.html)
 - [Tweak the KES server configuration](https://github.com/minio/kes/wiki/Configuration)
 - [Run a load balancer in front of KES](https://github.com/minio/kes/wiki/TLS-Proxy)
 - [Understand the KES server concepts](https://github.com/minio/kes/wiki/Concepts)
@@ -137,7 +137,7 @@ Certificates are no secrets and sent in plaintext as part of the TLS handshake.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/kms/README.md
+++ b/docs/kms/README.md
@@ -4,7 +4,7 @@ MinIO uses a key-management-system (KMS) to support SSE-S3. If a client requests
 
 ## Quick Start
 
-MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you haven't installed MinIO, yet, then follow the MinIO [install instructions](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html) first.
+MinIO supports multiple KMS implementations via our [KES](https://github.com/minio/kes#kes) project. We run a KES instance at `https://play.min.io:7373` for you to experiment and quickly get started. To run MinIO with a KMS just fetch the root identity, set the following environment variables and then start your MinIO server. If you haven't installed MinIO, yet, then follow the MinIO [install instructions](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html) first.
 
 ### 1. Fetch the root identity
 
@@ -67,7 +67,7 @@ The MinIO-KES configuration is always the same - regardless of the underlying KM
 
 ### Further references
 
-- [Run MinIO with TLS / HTTPS](https://docs.min.io/community/minio-object-store/operations/network-encryption.html)
+- [Run MinIO with TLS / HTTPS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
 - [Tweak the KES server configuration](https://github.com/minio/kes/wiki/Configuration)
 - [Run a load balancer in front of KES](https://github.com/minio/kes/wiki/TLS-Proxy)
 - [Understand the KES server concepts](https://github.com/minio/kes/wiki/Concepts)
@@ -137,7 +137,7 @@ Certificates are no secrets and sent in plaintext as part of the TLS handshake.
 
 ## Explore Further
 
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/lambda/README.md
+++ b/docs/lambda/README.md
@@ -4,7 +4,7 @@ MinIO's Object Lambda implementation allows for transforming your data to serve 
 
 MinIO's Object Lambda, enables application developers to process data retrieved from MinIO before returning it to an application. You can register a Lambda Function target on MinIO, once successfully registered it can be used to transform the data for application GET requests on demand.
 
-This document focuses on showing a working example on how to use Object Lambda with MinIO, you must have [MinIO deployed in your environment](https://docs.min.io/community/minio-object-store/operations/installation.html) before you can start using external lambda functions. You also must install Python version 3.8 or later for the lambda handlers to work.
+This document focuses on showing a working example on how to use Object Lambda with MinIO, you must have [MinIO deployed in your environment](https://silo.pigsty.io/community/minio-object-store/operations/installation.html) before you can start using external lambda functions. You also must install Python version 3.8 or later for the lambda handlers to work.
 
 ## Example Lambda handler
 
@@ -134,7 +134,7 @@ mc cp testobject myminio/functionbucket/
 
 ## Invoke Lambda transformation via PresignedGET
 
-Following example shows how you can use [`minio-go` PresignedGetObject](https://docs.min.io/community/minio-object-store/developers/go/API.html#presignedgetobject-ctx-context-context-bucketname-objectname-string-expiry-time-duration-reqparams-url-values-url-url-error)
+Following example shows how you can use [`minio-go` PresignedGetObject](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#presignedgetobject-ctx-context-context-bucketname-objectname-string-expiry-time-duration-reqparams-url-values-url-url-error)
 ```go
 package main
 

--- a/docs/lambda/README.md
+++ b/docs/lambda/README.md
@@ -4,7 +4,7 @@ MinIO's Object Lambda implementation allows for transforming your data to serve 
 
 MinIO's Object Lambda, enables application developers to process data retrieved from MinIO before returning it to an application. You can register a Lambda Function target on MinIO, once successfully registered it can be used to transform the data for application GET requests on demand.
 
-This document focuses on showing a working example on how to use Object Lambda with MinIO, you must have [MinIO deployed in your environment](https://silo.pigsty.io/community/minio-object-store/operations/installation.html) before you can start using external lambda functions. You also must install Python version 3.8 or later for the lambda handlers to work.
+This document focuses on showing a working example on how to use Object Lambda with MinIO, you must have [MinIO deployed in your environment](https://silo.pigsty.io/operations/installation.html) before you can start using external lambda functions. You also must install Python version 3.8 or later for the lambda handlers to work.
 
 ## Example Lambda handler
 
@@ -134,7 +134,7 @@ mc cp testobject myminio/functionbucket/
 
 ## Invoke Lambda transformation via PresignedGET
 
-Following example shows how you can use [`minio-go` PresignedGetObject](https://silo.pigsty.io/community/minio-object-store/developers/go/API.html#presignedgetobject-ctx-context-context-bucketname-objectname-string-expiry-time-duration-reqparams-url-values-url-url-error)
+Following example shows how you can use [`minio-go` PresignedGetObject](https://silo.pigsty.io/developers/go/API.html#presignedgetobject-ctx-context-context-bucketname-objectname-string-expiry-time-duration-reqparams-url-values-url-url-error)
 ```go
 package main
 

--- a/docs/logging/README.md
+++ b/docs/logging/README.md
@@ -17,7 +17,7 @@ Console target is on always and cannot be disabled.
 
 HTTP target logs to a generic HTTP endpoint in JSON format and is not enabled by default. To enable HTTP target logging you would have to update your MinIO server configuration using `mc admin config set` command.
 
-Assuming `mc` is already [configured](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+Assuming `mc` is already [configured](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
 
 ```
 mc admin config get myminio/ logger_webhook
@@ -42,7 +42,7 @@ minio server /mnt/data
 
 ## Audit Targets
 
-Assuming `mc` is already [configured](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+Assuming `mc` is already [configured](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
 
 ### Audit HTTP Target
 
@@ -224,5 +224,5 @@ NOTE:
 
 ## Explore Further
 
-- [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
-- [Configure MinIO Server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
+- [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- [Configure MinIO Server with TLS](https://silo.pigsty.io/operations/network-encryption.html)

--- a/docs/logging/README.md
+++ b/docs/logging/README.md
@@ -17,7 +17,7 @@ Console target is on always and cannot be disabled.
 
 HTTP target logs to a generic HTTP endpoint in JSON format and is not enabled by default. To enable HTTP target logging you would have to update your MinIO server configuration using `mc admin config set` command.
 
-Assuming `mc` is already [configured](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+Assuming `mc` is already [configured](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
 
 ```
 mc admin config get myminio/ logger_webhook
@@ -42,7 +42,7 @@ minio server /mnt/data
 
 ## Audit Targets
 
-Assuming `mc` is already [configured](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+Assuming `mc` is already [configured](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
 
 ### Audit HTTP Target
 
@@ -224,5 +224,5 @@ NOTE:
 
 ## Explore Further
 
-- [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
-- [Configure MinIO Server with TLS](https://docs.min.io/community/minio-object-store/operations/network-encryption.html)
+- [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- [Configure MinIO Server with TLS](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)

--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -9,7 +9,7 @@ This document explains how to setup Prometheus and configure it to scrape data f
 
 ## Prerequisites
 
-To get started with MinIO, refer [MinIO QuickStart Document](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+To get started with MinIO, refer [MinIO QuickStart Document](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 Follow below steps to get started with MinIO monitoring using Prometheus.
 
 ### 1. Download Prometheus
@@ -49,7 +49,7 @@ minio server ~/test
 
 > If MinIO is configured to expose metrics without authentication, you don't need to use `mc` to generate prometheus config. You can skip reading further and move to 3.2 section.
 
-The Prometheus endpoint in MinIO requires authentication by default. Prometheus supports a bearer token approach to authenticate prometheus scrape requests, override the default Prometheus config with the one generated using mc. To generate a Prometheus config for an alias, use [mc](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart) as follows `mc admin prometheus generate <alias> [METRIC-TYPE]`. The valid values for METRIC-TYPE are `cluster`, `node`, `bucket` and `resource` and if not mentioned, it defaults to `cluster`.
+The Prometheus endpoint in MinIO requires authentication by default. Prometheus supports a bearer token approach to authenticate prometheus scrape requests, override the default Prometheus config with the one generated using mc. To generate a Prometheus config for an alias, use [mc](https://silo.pigsty.io/reference/minio-mc.html#quickstart) as follows `mc admin prometheus generate <alias> [METRIC-TYPE]`. The valid values for METRIC-TYPE are `cluster`, `node`, `bucket` and `resource` and if not mentioned, it defaults to `cluster`.
 
 The command will generate the `scrape_configs` section of the prometheus.yml as follows:
 

--- a/docs/metrics/prometheus/README.md
+++ b/docs/metrics/prometheus/README.md
@@ -9,7 +9,7 @@ This document explains how to setup Prometheus and configure it to scrape data f
 
 ## Prerequisites
 
-To get started with MinIO, refer [MinIO QuickStart Document](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+To get started with MinIO, refer [MinIO QuickStart Document](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 Follow below steps to get started with MinIO monitoring using Prometheus.
 
 ### 1. Download Prometheus
@@ -49,7 +49,7 @@ minio server ~/test
 
 > If MinIO is configured to expose metrics without authentication, you don't need to use `mc` to generate prometheus config. You can skip reading further and move to 3.2 section.
 
-The Prometheus endpoint in MinIO requires authentication by default. Prometheus supports a bearer token approach to authenticate prometheus scrape requests, override the default Prometheus config with the one generated using mc. To generate a Prometheus config for an alias, use [mc](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart) as follows `mc admin prometheus generate <alias> [METRIC-TYPE]`. The valid values for METRIC-TYPE are `cluster`, `node`, `bucket` and `resource` and if not mentioned, it defaults to `cluster`.
+The Prometheus endpoint in MinIO requires authentication by default. Prometheus supports a bearer token approach to authenticate prometheus scrape requests, override the default Prometheus config with the one generated using mc. To generate a Prometheus config for an alias, use [mc](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart) as follows `mc admin prometheus generate <alias> [METRIC-TYPE]`. The valid values for METRIC-TYPE are `cluster`, `node`, `bucket` and `resource` and if not mentioned, it defaults to `cluster`.
 
 The command will generate the `scrape_configs` section of the prometheus.yml as follows:
 

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -78,8 +78,8 @@ For deployments behind a load balancer, use the load balancer hostname instead o
 
 ## Cluster Replication Metrics
 
-Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
-For deployments with [bucket](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
+Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/operations/install-deploy-manage/multi-site-replication.html) configurations.
+For deployments with [bucket](https://silo.pigsty.io/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
 
 | Name                                                       | Description                                                                                             
 |:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
@@ -108,8 +108,8 @@ For deployments with [bucket](https://silo.pigsty.io/community/minio-object-stor
 
 ## Node Replication Metrics
 
-Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
-For deployments with [bucket](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
+Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/operations/install-deploy-manage/multi-site-replication.html) configurations.
+For deployments with [bucket](https://silo.pigsty.io/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
 
 | Name                                                       | Description
 |:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
@@ -296,8 +296,8 @@ For deployments behind a load balancer, use the load balancer hostname instead o
 
 ## Replication Metrics
 
-These metrics only populate on deployments with [Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [Batch Replication](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html) configurations.
-For deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configured, select metrics populate under the [Cluster Metrics](#cluster-metrics) endpoint.
+These metrics only populate on deployments with [Bucket Replication](https://silo.pigsty.io/administration/bucket-replication.html) or [Batch Replication](https://silo.pigsty.io/administration/batch-framework.html) configurations.
+For deployments with [Site Replication](https://silo.pigsty.io/operations/install-deploy-manage/multi-site-replication.html) configured, select metrics populate under the [Cluster Metrics](#cluster-metrics) endpoint.
 
 | Name                                                | Description                                                                      |
 |:----------------------------------------------------|:---------------------------------------------------------------------------------|

--- a/docs/metrics/prometheus/list.md
+++ b/docs/metrics/prometheus/list.md
@@ -78,8 +78,8 @@ For deployments behind a load balancer, use the load balancer hostname instead o
 
 ## Cluster Replication Metrics
 
-Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
-For deployments with [bucket](https://docs.min.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://docs.min.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
+Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
+For deployments with [bucket](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
 
 | Name                                                       | Description                                                                                             
 |:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
@@ -108,8 +108,8 @@ For deployments with [bucket](https://docs.min.io/community/minio-object-store/a
 
 ## Node Replication Metrics
 
-Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
-For deployments with [bucket](https://docs.min.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://docs.min.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
+Metrics marked as ``Site Replication Only`` only populate on deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configurations.
+For deployments with [bucket](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [batch](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html#replicate) configurations, these metrics populate instead under the [Bucket Metrics](#bucket-metrics) endpoint.
 
 | Name                                                       | Description
 |:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------|
@@ -296,8 +296,8 @@ For deployments behind a load balancer, use the load balancer hostname instead o
 
 ## Replication Metrics
 
-These metrics only populate on deployments with [Bucket Replication](https://docs.min.io/community/minio-object-store/administration/bucket-replication.html) or [Batch Replication](https://docs.min.io/community/minio-object-store/administration/batch-framework.html) configurations.
-For deployments with [Site Replication](https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configured, select metrics populate under the [Cluster Metrics](#cluster-metrics) endpoint.
+These metrics only populate on deployments with [Bucket Replication](https://silo.pigsty.io/community/minio-object-store/administration/bucket-replication.html) or [Batch Replication](https://silo.pigsty.io/community/minio-object-store/administration/batch-framework.html) configurations.
+For deployments with [Site Replication](https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/multi-site-replication.html) configured, select metrics populate under the [Cluster Metrics](#cluster-metrics) endpoint.
 
 | Name                                                | Description                                                                      |
 |:----------------------------------------------------|:---------------------------------------------------------------------------------|

--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -42,14 +42,14 @@ We found the following APIs to be redundant or less useful outside of AWS S3. If
 
 ### List of Amazon S3 Bucket APIs not supported on MinIO
 
-- BucketACL (Use [bucket policies](https://docs.min.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
+- BucketACL (Use [bucket policies](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
 - BucketCORS (CORS enabled by default on all buckets for all HTTP verbs, you can optionally restrict the CORS domains)
 - BucketWebsite (Use [`caddy`](https://github.com/caddyserver/caddy) or [`nginx`](https://www.nginx.com/resources/wiki/))
-- BucketAnalytics, BucketMetrics, BucketLogging (Use [bucket notification](https://docs.min.io/community/minio-object-store/administration/monitoring/bucket-notifications.html) APIs)
+- BucketAnalytics, BucketMetrics, BucketLogging (Use [bucket notification](https://silo.pigsty.io/community/minio-object-store/administration/monitoring/bucket-notifications.html) APIs)
 
 ### List of Amazon S3 Object APIs not supported on MinIO
 
-- ObjectACL (Use [bucket policies](https://docs.min.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
+- ObjectACL (Use [bucket policies](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
 
 ## Object name restrictions on MinIO
 

--- a/docs/minio-limits.md
+++ b/docs/minio-limits.md
@@ -42,14 +42,14 @@ We found the following APIs to be redundant or less useful outside of AWS S3. If
 
 ### List of Amazon S3 Bucket APIs not supported on MinIO
 
-- BucketACL (Use [bucket policies](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
+- BucketACL (Use [bucket policies](https://silo.pigsty.io/administration/identity-access-management/policy-based-access-control.html) instead)
 - BucketCORS (CORS enabled by default on all buckets for all HTTP verbs, you can optionally restrict the CORS domains)
 - BucketWebsite (Use [`caddy`](https://github.com/caddyserver/caddy) or [`nginx`](https://www.nginx.com/resources/wiki/))
-- BucketAnalytics, BucketMetrics, BucketLogging (Use [bucket notification](https://silo.pigsty.io/community/minio-object-store/administration/monitoring/bucket-notifications.html) APIs)
+- BucketAnalytics, BucketMetrics, BucketLogging (Use [bucket notification](https://silo.pigsty.io/administration/monitoring/bucket-notifications.html) APIs)
 
 ### List of Amazon S3 Object APIs not supported on MinIO
 
-- ObjectACL (Use [bucket policies](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/policy-based-access-control.html) instead)
+- ObjectACL (Use [bucket policies](https://silo.pigsty.io/administration/identity-access-management/policy-based-access-control.html) instead)
 
 ## Object name restrictions on MinIO
 

--- a/docs/multi-tenancy/README.md
+++ b/docs/multi-tenancy/README.md
@@ -64,4 +64,4 @@ minio server --address :9003 http://192.168.10.1{1...4}/data/tenant3
 
 ## Cloud Scale Deployment
 
-A container orchestration platform (e.g. Kubernetes) is recommended for large-scale, multi-tenant MinIO deployments. See the [MinIO Deployment Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html) to get started with MinIO on orchestration platforms.
+A container orchestration platform (e.g. Kubernetes) is recommended for large-scale, multi-tenant MinIO deployments. See the [MinIO Deployment Quickstart Guide](https://silo.pigsty.io/operations/deployments/kubernetes.html) to get started with MinIO on orchestration platforms.

--- a/docs/multi-tenancy/README.md
+++ b/docs/multi-tenancy/README.md
@@ -64,4 +64,4 @@ minio server --address :9003 http://192.168.10.1{1...4}/data/tenant3
 
 ## Cloud Scale Deployment
 
-A container orchestration platform (e.g. Kubernetes) is recommended for large-scale, multi-tenant MinIO deployments. See the [MinIO Deployment Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html) to get started with MinIO on orchestration platforms.
+A container orchestration platform (e.g. Kubernetes) is recommended for large-scale, multi-tenant MinIO deployments. See the [MinIO Deployment Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html) to get started with MinIO on orchestration platforms.

--- a/docs/multi-user/README.md
+++ b/docs/multi-user/README.md
@@ -8,13 +8,13 @@ In this document we will explain in detail on how to configure multiple users.
 
 ### 1. Prerequisites
 
-- Install mc - [MinIO Client Quickstart Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 - Configure etcd - [Etcd V3 Quickstart Guide](https://github.com/pgsty/minio/blob/master/docs/sts/etcd.md)
 
 ### 2. Create a new user with canned policy
 
-Use [`mc admin policy`](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policy` command.
+Use [`mc admin policy`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policy` command.
 
 Create new canned policy file `getonly.json`. This policy enables users to download all objects under `my-bucketname`.
 
@@ -272,7 +272,7 @@ Following example shows LDAP users full programmatic access to a LDAP user-speci
 
 ## Explore Further
 
-- [MinIO Client Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/multi-user/README.md
+++ b/docs/multi-user/README.md
@@ -8,13 +8,13 @@ In this document we will explain in detail on how to configure multiple users.
 
 ### 1. Prerequisites
 
-- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 - Configure etcd - [Etcd V3 Quickstart Guide](https://github.com/pgsty/minio/blob/master/docs/sts/etcd.md)
 
 ### 2. Create a new user with canned policy
 
-Use [`mc admin policy`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policy` command.
+Use [`mc admin policy`](https://silo.pigsty.io/reference/minio-mc-admin/mc-admin-policy.html) to create canned policies. Server provides a default set of canned policies namely `writeonly`, `readonly` and `readwrite` *(these policies apply to all resources on the server)*. These can be overridden by custom policies using `mc admin policy` command.
 
 Create new canned policy file `getonly.json`. This policy enables users to download all objects under `my-bucketname`.
 
@@ -272,7 +272,7 @@ Following example shows LDAP users full programmatic access to a LDAP user-speci
 
 ## Explore Further
 
-- [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Client Complete Guide](https://silo.pigsty.io/reference/minio-mc.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/multi-user/admin/README.md
+++ b/docs/multi-user/admin/README.md
@@ -8,12 +8,12 @@ In this document we will explain in detail on how to configure admin users.
 
 ### 1. Prerequisites
 
-- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 
 ### 2. Create a new admin user with CreateUser, DeleteUser and ConfigUpdate permissions
 
-Use [`mc admin policy`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html#command-mc.admin.policy) to create custom admin policies.
+Use [`mc admin policy`](https://silo.pigsty.io/reference/minio-mc-admin/mc-admin-policy.html#command-mc.admin.policy) to create custom admin policies.
 
 Create new canned policy file `adminManageUser.json`. This policy enables admin user to
 manage other users.
@@ -162,11 +162,11 @@ mc admin policy attach myminio-admin1 user1policy --user=user1
 ### 5. Using an external IDP for admin users
 
 Admin users can also be externally managed by an IDP by configuring admin policy with
-special permissions listed above. Follow [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html) to manage users with an IDP.
+special permissions listed above. Follow [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html) to manage users with an IDP.
 
 ## Explore Further
 
-- [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Client Complete Guide](https://silo.pigsty.io/reference/minio-mc.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/multi-user/admin/README.md
+++ b/docs/multi-user/admin/README.md
@@ -8,12 +8,12 @@ In this document we will explain in detail on how to configure admin users.
 
 ### 1. Prerequisites
 
-- Install mc - [MinIO Client Quickstart Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart)
-- Install MinIO - [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
+- Install mc - [MinIO Client Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart)
+- Install MinIO - [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html)
 
 ### 2. Create a new admin user with CreateUser, DeleteUser and ConfigUpdate permissions
 
-Use [`mc admin policy`](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html#command-mc.admin.policy) to create custom admin policies.
+Use [`mc admin policy`](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin/mc-admin-policy.html#command-mc.admin.policy) to create custom admin policies.
 
 Create new canned policy file `adminManageUser.json`. This policy enables admin user to
 manage other users.
@@ -162,11 +162,11 @@ mc admin policy attach myminio-admin1 user1policy --user=user1
 ### 5. Using an external IDP for admin users
 
 Admin users can also be externally managed by an IDP by configuring admin policy with
-special permissions listed above. Follow [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html) to manage users with an IDP.
+special permissions listed above. Follow [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html) to manage users with an IDP.
 
 ## Explore Further
 
-- [MinIO Client Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -4,7 +4,7 @@ MinIO is a cloud-native application designed to scale in a sustainable manner in
 
 | Orchestration platforms                                                                            |
 |:---------------------------------------------------------------------------------------------------|
-| [`Kubernetes`](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html)                                |
+| [`Kubernetes`](https://silo.pigsty.io/operations/deployments/kubernetes.html)                                |
 
 ## Why is MinIO cloud-native?
 

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -4,7 +4,7 @@ MinIO is a cloud-native application designed to scale in a sustainable manner in
 
 | Orchestration platforms                                                                            |
 |:---------------------------------------------------------------------------------------------------|
-| [`Kubernetes`](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html)                                |
+| [`Kubernetes`](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html)                                |
 
 ## Why is MinIO cloud-native?
 

--- a/docs/orchestration/docker-compose/README.md
+++ b/docs/orchestration/docker-compose/README.md
@@ -50,10 +50,10 @@ Distributed instances are now accessible on the host using the Minio CLI on port
   * Update the command section in each service.
   * Add a new MinIO server instance to the upstream directive in the Nginx configuration file.
 
-  Read more about distributed MinIO [here](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html).
+  Read more about distributed MinIO [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html).
 
 ### Explore Further
 
 * [Overview of Docker Compose](https://docs.docker.com/compose/overview/)
-* [MinIO Docker Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
-* [MinIO Erasure Code QuickStart Guide](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+* [MinIO Docker Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
+* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)

--- a/docs/orchestration/docker-compose/README.md
+++ b/docs/orchestration/docker-compose/README.md
@@ -50,10 +50,10 @@ Distributed instances are now accessible on the host using the Minio CLI on port
   * Update the command section in each service.
   * Add a new MinIO server instance to the upstream directive in the Nginx configuration file.
 
-  Read more about distributed MinIO [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html).
+  Read more about distributed MinIO [here](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-as-a-container.html).
 
 ### Explore Further
 
 * [Overview of Docker Compose](https://docs.docker.com/compose/overview/)
-* [MinIO Docker Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-as-a-container.html)
-* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+* [MinIO Docker Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-as-a-container.html)
+* [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/operations/concepts/erasure-coding.html)

--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -16,6 +16,6 @@ MinIO server exposes un-authenticated liveness endpoints so Kubernetes can nativ
 
 ## Explore Further
 
-- [MinIO Erasure Code QuickStart Guide](https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
 - [Kubernetes Documentation](https://kubernetes.io/docs/home/)
 - [Helm package manager for kubernetes](https://helm.sh/)

--- a/docs/orchestration/kubernetes/README.md
+++ b/docs/orchestration/kubernetes/README.md
@@ -16,6 +16,6 @@ MinIO server exposes un-authenticated liveness endpoints so Kubernetes can nativ
 
 ## Explore Further
 
-- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html)
+- [MinIO Erasure Code QuickStart Guide](https://silo.pigsty.io/operations/concepts/erasure-coding.html)
 - [Kubernetes Documentation](https://kubernetes.io/docs/home/)
 - [Helm package manager for kubernetes](https://helm.sh/)

--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -12,7 +12,7 @@ You can use the Select API to query objects with following features:
 
 Type inference and automatic conversion of values is performed based on the context when the value is un-typed (such as when reading CSV data). If present, the CAST function overrides automatic conversion.
 
-The [mc sql](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-sql.html) command can be used for executing queries using the command line.
+The [mc sql](https://silo.pigsty.io/reference/minio-mc/mc-sql.html) command can be used for executing queries using the command line.
 
 (*) Parquet is disabled on the MinIO server by default. See below how to enable it.
 
@@ -27,7 +27,7 @@ To enable Parquet set the environment variable `MINIO_API_SELECT_PARQUET=on`.
 
 ### 1. Prerequisites
 
-- Install MinIO Server from [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- Install MinIO Server from [here](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
 - Familiarity with AWS S3 API.
 - Familiarity with Python and installing dependencies.
 
@@ -113,11 +113,11 @@ For a more detailed SELECT SQL reference, please see [here](https://docs.aws.ama
 
 ## 5. Explore Further
 
-- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `mc sql` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-sql.html#command-mc.sql)
-- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
-- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/reference/minio-mc.html)
+- [Use `mc sql` with MinIO Server](https://silo.pigsty.io/reference/minio-mc/mc-sql.html#command-mc.sql)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/developers/go/minio-go.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/integrations/aws-cli-with-minio.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)
 
 ## 6. Implementation Status
 

--- a/docs/select/README.md
+++ b/docs/select/README.md
@@ -12,7 +12,7 @@ You can use the Select API to query objects with following features:
 
 Type inference and automatic conversion of values is performed based on the context when the value is un-typed (such as when reading CSV data). If present, the CAST function overrides automatic conversion.
 
-The [mc sql](https://docs.min.io/community/minio-object-store/reference/minio-mc/mc-sql.html) command can be used for executing queries using the command line.
+The [mc sql](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-sql.html) command can be used for executing queries using the command line.
 
 (*) Parquet is disabled on the MinIO server by default. See below how to enable it.
 
@@ -27,7 +27,7 @@ To enable Parquet set the environment variable `MINIO_API_SELECT_PARQUET=on`.
 
 ### 1. Prerequisites
 
-- Install MinIO Server from [here](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
+- Install MinIO Server from [here](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html#procedure).
 - Familiarity with AWS S3 API.
 - Familiarity with Python and installing dependencies.
 
@@ -113,11 +113,11 @@ For a more detailed SELECT SQL reference, please see [here](https://docs.aws.ama
 
 ## 5. Explore Further
 
-- [Use `mc` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-- [Use `mc sql` with MinIO Server](https://docs.min.io/community/minio-object-store/reference/minio-mc/mc-sql.html#command-mc.sql)
-- [Use `minio-go` SDK with MinIO Server](https://docs.min.io/community/minio-object-store/developers/go/minio-go.html)
-- [Use `aws-cli` with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [Use `mc` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+- [Use `mc sql` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc/mc-sql.html#command-mc.sql)
+- [Use `minio-go` SDK with MinIO Server](https://silo.pigsty.io/community/minio-object-store/developers/go/minio-go.html)
+- [Use `aws-cli` with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/aws-cli-with-minio.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
 
 ## 6. Implementation Status
 

--- a/docs/site-replication/README.md
+++ b/docs/site-replication/README.md
@@ -25,7 +25,7 @@ The following Bucket features will **not be replicated**, is designed to differ 
 
 - **Removing a site** is not allowed from a set of replicated sites once configured.
 - All sites must be using the **same** external IDP(s) if any.
-- For [SSE-S3 or SSE-KMS encryption via KMS](https://silo.pigsty.io/community/minio-object-store/operations/server-side-encryption.html "MinIO KMS Guide"), all sites **must**  have access to a central KMS deployment. This can be achieved via a central KES server or multiple KES servers (say one per site) connected via a central KMS (Vault) server.
+- For [SSE-S3 or SSE-KMS encryption via KMS](https://silo.pigsty.io/operations/server-side-encryption.html "MinIO KMS Guide"), all sites **must**  have access to a central KMS deployment. This can be achieved via a central KES server or multiple KES servers (say one per site) connected via a central KMS (Vault) server.
 
 ## Configuring Site Replication
 

--- a/docs/site-replication/README.md
+++ b/docs/site-replication/README.md
@@ -25,7 +25,7 @@ The following Bucket features will **not be replicated**, is designed to differ 
 
 - **Removing a site** is not allowed from a set of replicated sites once configured.
 - All sites must be using the **same** external IDP(s) if any.
-- For [SSE-S3 or SSE-KMS encryption via KMS](https://docs.min.io/community/minio-object-store/operations/server-side-encryption.html "MinIO KMS Guide"), all sites **must**  have access to a central KMS deployment. This can be achieved via a central KES server or multiple KES servers (say one per site) connected via a central KMS (Vault) server.
+- For [SSE-S3 or SSE-KMS encryption via KMS](https://silo.pigsty.io/community/minio-object-store/operations/server-side-encryption.html "MinIO KMS Guide"), all sites **must**  have access to a central KMS deployment. This can be achieved via a central KES server or multiple KES servers (say one per site) connected via a central KMS (Vault) server.
 
 ## Configuring Site Replication
 

--- a/docs/sts/README.md
+++ b/docs/sts/README.md
@@ -106,5 +106,5 @@ These credentials can now be used to perform MinIO API operations.
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/README.md
+++ b/docs/sts/README.md
@@ -106,5 +106,5 @@ These credentials can now be used to perform MinIO API operations.
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/assume-role.md
+++ b/docs/sts/assume-role.md
@@ -89,7 +89,7 @@ export MINIO_ROOT_PASSWORD=minio123
 minio server ~/test
 ```
 
-Create new users following the multi-user guide [here](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management.html)
+Create new users following the multi-user guide [here](https://silo.pigsty.io/administration/identity-access-management.html)
 
 ### Testing an example with awscli tool
 
@@ -134,5 +134,5 @@ SessionToken: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiIyN1lEUllFT
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/assume-role.md
+++ b/docs/sts/assume-role.md
@@ -89,7 +89,7 @@ export MINIO_ROOT_PASSWORD=minio123
 minio server ~/test
 ```
 
-Create new users following the multi-user guide [here](https://docs.min.io/community/minio-object-store/administration/identity-access-management.html)
+Create new users following the multi-user guide [here](https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management.html)
 
 ### Testing an example with awscli tool
 
@@ -134,5 +134,5 @@ SessionToken: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2Nlc3NLZXkiOiIyN1lEUllFT
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/casdoor.md
+++ b/docs/sts/casdoor.md
@@ -112,5 +112,5 @@ This will open the login page of Casdoor, upon successful login, STS credentials
 ## Explore Further
 
 - [Casdoor MinIO Integration](https://casdoor.org/docs/integration/minio)
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/casdoor.md
+++ b/docs/sts/casdoor.md
@@ -112,5 +112,5 @@ This will open the login page of Casdoor, upon successful login, STS credentials
 ## Explore Further
 
 - [Casdoor MinIO Integration](https://casdoor.org/docs/integration/minio)
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/client-grants.md
+++ b/docs/sts/client-grants.md
@@ -113,5 +113,5 @@ $ go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBt
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/client-grants.md
+++ b/docs/sts/client-grants.md
@@ -113,5 +113,5 @@ $ go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBt
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/dex.md
+++ b/docs/sts/dex.md
@@ -99,5 +99,5 @@ and add relevant policies on MinIO using `mc admin policy create myminio/ <group
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/dex.md
+++ b/docs/sts/dex.md
@@ -99,5 +99,5 @@ and add relevant policies on MinIO using `mc admin policy create myminio/ <group
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/etcd.md
+++ b/docs/sts/etcd.md
@@ -50,7 +50,7 @@ NOTE: If `etcd` is configured with `Client-to-server authentication with HTTPS c
 
 Once etcd is configured, **any STS configuration** will work including Client Grants, Web Identity or AD/LDAP.
 
-For example, you can configure STS with Client Grants (KeyCloak) using the guides at [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html) and [KeyCloak Configuration Guide](https://github.com/pgsty/minio/blob/master/docs/sts/keycloak.md). Once this is done, STS credentials can be generated:
+For example, you can configure STS with Client Grants (KeyCloak) using the guides at [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html) and [KeyCloak Configuration Guide](https://github.com/pgsty/minio/blob/master/docs/sts/keycloak.md). Once this is done, STS credentials can be generated:
 
 ```
 go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBtrOWvhRWL4TUCga
@@ -68,5 +68,5 @@ These credentials can now be used to perform MinIO API operations, these credent
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/etcd.md
+++ b/docs/sts/etcd.md
@@ -50,7 +50,7 @@ NOTE: If `etcd` is configured with `Client-to-server authentication with HTTPS c
 
 Once etcd is configured, **any STS configuration** will work including Client Grants, Web Identity or AD/LDAP.
 
-For example, you can configure STS with Client Grants (KeyCloak) using the guides at [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html) and [KeyCloak Configuration Guide](https://github.com/pgsty/minio/blob/master/docs/sts/keycloak.md). Once this is done, STS credentials can be generated:
+For example, you can configure STS with Client Grants (KeyCloak) using the guides at [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html) and [KeyCloak Configuration Guide](https://github.com/pgsty/minio/blob/master/docs/sts/keycloak.md). Once this is done, STS credentials can be generated:
 
 ```
 go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBtrOWvhRWL4TUCga
@@ -68,5 +68,5 @@ These credentials can now be used to perform MinIO API operations, these credent
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/keycloak.md
+++ b/docs/sts/keycloak.md
@@ -172,5 +172,5 @@ These credentials can now be used to perform MinIO API operations.
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/keycloak.md
+++ b/docs/sts/keycloak.md
@@ -172,5 +172,5 @@ These credentials can now be used to perform MinIO API operations.
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -365,5 +365,5 @@ $ go run ldap.go -u foouser -p foopassword
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/ldap.md
+++ b/docs/sts/ldap.md
@@ -365,5 +365,5 @@ $ go run ldap.go -u foouser -p foopassword
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/tls.md
+++ b/docs/sts/tls.md
@@ -113,5 +113,5 @@ Further, the temp. S3 credentials will never out-live the client certificate. Fo
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/tls.md
+++ b/docs/sts/tls.md
@@ -113,5 +113,5 @@ Further, the temp. S3 credentials will never out-live the client certificate. Fo
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -273,5 +273,5 @@ JWT token returned by the Identity Provider should include a custom claim for th
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/web-identity.md
+++ b/docs/sts/web-identity.md
@@ -273,5 +273,5 @@ JWT token returned by the Identity Provider should include a custom claim for th
 
 ## Explore Further
 
-- [MinIO Admin Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc-admin.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO Admin Complete Guide](https://silo.pigsty.io/reference/minio-mc-admin.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/sts/wso2.md
+++ b/docs/sts/wso2.md
@@ -87,7 +87,7 @@ export MINIO_IDENTITY_OPENID_CLIENT_ID="843351d4-1080-11ea-aa20-271ecba3924a"
 minio server /mnt/data
 ```
 
-Assuming that MinIO server is configured to support STS API by following the doc [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html), execute the following command to temporary credentials from MinIO server.
+Assuming that MinIO server is configured to support STS API by following the doc [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html), execute the following command to temporary credentials from MinIO server.
 
 ```
 go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBtrOWvhRWL4TUCga
@@ -105,5 +105,5 @@ These credentials can now be used to perform MinIO API operations, these credent
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://docs.min.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://docs.min.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)

--- a/docs/sts/wso2.md
+++ b/docs/sts/wso2.md
@@ -87,7 +87,7 @@ export MINIO_IDENTITY_OPENID_CLIENT_ID="843351d4-1080-11ea-aa20-271ecba3924a"
 minio server /mnt/data
 ```
 
-Assuming that MinIO server is configured to support STS API by following the doc [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html), execute the following command to temporary credentials from MinIO server.
+Assuming that MinIO server is configured to support STS API by following the doc [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html), execute the following command to temporary credentials from MinIO server.
 
 ```
 go run client-grants.go -cid PoEgXP6uVO45IsENRngDXj5Au5Ya -csec eKsw6z8CtOJVBtrOWvhRWL4TUCga
@@ -105,5 +105,5 @@ These credentials can now be used to perform MinIO API operations, these credent
 
 ## Explore Further
 
-- [MinIO STS Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/developers/security-token-service.html)
-- [The MinIO documentation website](https://silo.pigsty.io/community/minio-object-store/index.html)
+- [MinIO STS Quickstart Guide](https://silo.pigsty.io/developers/security-token-service.html)
+- [The MinIO documentation website](https://silo.pigsty.io/index.html)

--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -9,11 +9,11 @@ This guide explains how to configure MinIO Server with TLS certificates on Linux
 
 ## 1. Install MinIO Server
 
-Install MinIO Server using the instructions in the [MinIO Quickstart Guide](https://docs.min.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO Server using the instructions in the [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ## 2. Use an Existing Key and Certificate with MinIO
 
-This section describes how to use a private key and public certificate that have been obtained from a certificate authority (CA). If these files have not been obtained, skip to [3. Generate Self-signed Certificates](#generate-use-self-signed-keys-certificates) or generate them with [Let's Encrypt](https://letsencrypt.org) using these instructions: [Generate Let's Encrypt certificate using Certbot for MinIO](https://docs.min.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html). For more about TLS and certificates in MinIO, see the [Network Encryption documentation](https://docs.min.io/community/minio-object-store/operations/network-encryption.html).
+This section describes how to use a private key and public certificate that have been obtained from a certificate authority (CA). If these files have not been obtained, skip to [3. Generate Self-signed Certificates](#generate-use-self-signed-keys-certificates) or generate them with [Let's Encrypt](https://letsencrypt.org) using these instructions: [Generate Let's Encrypt certificate using Certbot for MinIO](https://silo.pigsty.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html). For more about TLS and certificates in MinIO, see the [Network Encryption documentation](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
 
 Copy the existing private key and public certificate to the `certs` directory. The default certs directory is:
 
@@ -238,7 +238,7 @@ MinIO can connect to other servers, including MinIO nodes or other server types 
 ## Explore Further
 
 * [TLS Configuration for MinIO server on Kubernetes](https://github.com/pgsty/minio/tree/master/docs/tls/kubernetes)
-* [MinIO Client Complete Guide](https://docs.min.io/community/minio-object-store/reference/minio-mc.html)
-* [MinIO Network Encryption Overview](https://docs.min.io/community/minio-object-store/operations/network-encryption.html)
-* [Generate Let's Encrypt Certificate](https://docs.min.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html)
-* [Setup nginx Proxy with MinIO Server](https://docs.min.io/community/minio-object-store/integrations/setup-nginx-proxy-with-minio.html)
+* [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
+* [MinIO Network Encryption Overview](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
+* [Generate Let's Encrypt Certificate](https://silo.pigsty.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html)
+* [Setup nginx Proxy with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/setup-nginx-proxy-with-minio.html)

--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -9,11 +9,11 @@ This guide explains how to configure MinIO Server with TLS certificates on Linux
 
 ## 1. Install MinIO Server
 
-Install MinIO Server using the instructions in the [MinIO Quickstart Guide](https://silo.pigsty.io/community/minio-object-store/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
+Install MinIO Server using the instructions in the [MinIO Quickstart Guide](https://silo.pigsty.io/operations/deployments/baremetal-deploy-minio-on-redhat-linux.html).
 
 ## 2. Use an Existing Key and Certificate with MinIO
 
-This section describes how to use a private key and public certificate that have been obtained from a certificate authority (CA). If these files have not been obtained, skip to [3. Generate Self-signed Certificates](#generate-use-self-signed-keys-certificates) or generate them with [Let's Encrypt](https://letsencrypt.org) using these instructions: [Generate Let's Encrypt certificate using Certbot for MinIO](https://silo.pigsty.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html). For more about TLS and certificates in MinIO, see the [Network Encryption documentation](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
+This section describes how to use a private key and public certificate that have been obtained from a certificate authority (CA). If these files have not been obtained, skip to [3. Generate Self-signed Certificates](#generate-use-self-signed-keys-certificates) or generate them with [Let's Encrypt](https://letsencrypt.org) using these instructions: [Generate Let's Encrypt certificate using Certbot for MinIO](https://silo.pigsty.io/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html). For more about TLS and certificates in MinIO, see the [Network Encryption documentation](https://silo.pigsty.io/operations/network-encryption.html).
 
 Copy the existing private key and public certificate to the `certs` directory. The default certs directory is:
 
@@ -238,7 +238,7 @@ MinIO can connect to other servers, including MinIO nodes or other server types 
 ## Explore Further
 
 * [TLS Configuration for MinIO server on Kubernetes](https://github.com/pgsty/minio/tree/master/docs/tls/kubernetes)
-* [MinIO Client Complete Guide](https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html)
-* [MinIO Network Encryption Overview](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html)
-* [Generate Let's Encrypt Certificate](https://silo.pigsty.io/community/minio-object-store/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html)
-* [Setup nginx Proxy with MinIO Server](https://silo.pigsty.io/community/minio-object-store/integrations/setup-nginx-proxy-with-minio.html)
+* [MinIO Client Complete Guide](https://silo.pigsty.io/reference/minio-mc.html)
+* [MinIO Network Encryption Overview](https://silo.pigsty.io/operations/network-encryption.html)
+* [Generate Let's Encrypt Certificate](https://silo.pigsty.io/integrations/generate-lets-encrypt-certificate-using-certbot-for-minio.html)
+* [Setup nginx Proxy with MinIO Server](https://silo.pigsty.io/integrations/setup-nginx-proxy-with-minio.html)

--- a/docs/tls/kubernetes/README.md
+++ b/docs/tls/kubernetes/README.md
@@ -4,13 +4,13 @@ This document explains how to configure MinIO server with TLS certificates on Ku
 
 ## 1. Prerequisites
 
-- Familiarity with [MinIO deployment process on Kubernetes](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html).
+- Familiarity with [MinIO deployment process on Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html).
 
 - Kubernetes cluster with `kubectl` configured.
 
-- Acquire TLS certificates, either from a CA or [create self-signed certificates](https://docs.min.io/community/minio-object-store/operations/network-encryption.html).
+- Acquire TLS certificates, either from a CA or [create self-signed certificates](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
 
-For a [distributed MinIO setup](https://docs.min.io/community/minio-object-store/operations/deployments/kubernetes.html), where there are multiple pods with different domain names expected to run, you will either need wildcard certificates valid for all the domains or have specific certificates for each domain. If you are going to use specific certificates, make sure to create Kubernetes secrets accordingly.
+For a [distributed MinIO setup](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html), where there are multiple pods with different domain names expected to run, you will either need wildcard certificates valid for all the domains or have specific certificates for each domain. If you are going to use specific certificates, make sure to create Kubernetes secrets accordingly.
 
 For testing purposes, here is [how to create self-signed certificates](https://github.com/pgsty/minio/tree/master/docs/tls#3-generate-self-signed-certificates).
 

--- a/docs/tls/kubernetes/README.md
+++ b/docs/tls/kubernetes/README.md
@@ -4,13 +4,13 @@ This document explains how to configure MinIO server with TLS certificates on Ku
 
 ## 1. Prerequisites
 
-- Familiarity with [MinIO deployment process on Kubernetes](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html).
+- Familiarity with [MinIO deployment process on Kubernetes](https://silo.pigsty.io/operations/deployments/kubernetes.html).
 
 - Kubernetes cluster with `kubectl` configured.
 
-- Acquire TLS certificates, either from a CA or [create self-signed certificates](https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html).
+- Acquire TLS certificates, either from a CA or [create self-signed certificates](https://silo.pigsty.io/operations/network-encryption.html).
 
-For a [distributed MinIO setup](https://silo.pigsty.io/community/minio-object-store/operations/deployments/kubernetes.html), where there are multiple pods with different domain names expected to run, you will either need wildcard certificates valid for all the domains or have specific certificates for each domain. If you are going to use specific certificates, make sure to create Kubernetes secrets accordingly.
+For a [distributed MinIO setup](https://silo.pigsty.io/operations/deployments/kubernetes.html), where there are multiple pods with different domain names expected to run, you will either need wildcard certificates valid for all the domains or have specific certificates for each domain. If you are going to use specific certificates, make sure to create Kubernetes secrets accordingly.
 
 For testing purposes, here is [how to create self-signed certificates](https://github.com/pgsty/minio/tree/master/docs/tls#3-generate-self-signed-certificates).
 

--- a/helm/minio/README.md
+++ b/helm/minio/README.md
@@ -6,7 +6,7 @@ MinIO is a High Performance Object Storage released under GNU Affero General Pub
 
 | IMPORTANT |
 | -------------------------- |
-| This Helm chart is community built, maintained, and supported. MinIO does not guarantee support for any given bug, feature request, or update referencing this chart. <br/><br/> MinIO publishes a separate [MinIO Kubernetes Operator and Tenant Helm Chart](https://github.com/minio/operator/tree/master/helm) that is officially maintained and supported. MinIO strongly recommends using the MinIO Kubernetes Operator for production deployments. See [Deploy Operator With Helm](https://silo.pigsty.io/community/minio-object-store/operations/deployments/k8s-deploy-operator-helm-on-kubernetes.html?ref=github) for additional documentation. |
+| This Helm chart is community built, maintained, and supported. MinIO does not guarantee support for any given bug, feature request, or update referencing this chart. <br/><br/> MinIO publishes a separate [MinIO Kubernetes Operator and Tenant Helm Chart](https://github.com/minio/operator/tree/master/helm) that is officially maintained and supported. MinIO strongly recommends using the MinIO Kubernetes Operator for production deployments. See [Deploy Operator With Helm](https://silo.pigsty.io/operations/deployments/k8s-deploy-operator-helm-on-kubernetes.html?ref=github) for additional documentation. |
 
 ## Introduction
 

--- a/helm/minio/README.md
+++ b/helm/minio/README.md
@@ -6,7 +6,7 @@ MinIO is a High Performance Object Storage released under GNU Affero General Pub
 
 | IMPORTANT |
 | -------------------------- |
-| This Helm chart is community built, maintained, and supported. MinIO does not guarantee support for any given bug, feature request, or update referencing this chart. <br/><br/> MinIO publishes a separate [MinIO Kubernetes Operator and Tenant Helm Chart](https://github.com/minio/operator/tree/master/helm) that is officially maintained and supported. MinIO strongly recommends using the MinIO Kubernetes Operator for production deployments. See [Deploy Operator With Helm](https://docs.min.io/community/minio-object-store/operations/deployments/k8s-deploy-operator-helm-on-kubernetes.html?ref=github) for additional documentation. |
+| This Helm chart is community built, maintained, and supported. MinIO does not guarantee support for any given bug, feature request, or update referencing this chart. <br/><br/> MinIO publishes a separate [MinIO Kubernetes Operator and Tenant Helm Chart](https://github.com/minio/operator/tree/master/helm) that is officially maintained and supported. MinIO strongly recommends using the MinIO Kubernetes Operator for production deployments. See [Deploy Operator With Helm](https://silo.pigsty.io/community/minio-object-store/operations/deployments/k8s-deploy-operator-helm-on-kubernetes.html?ref=github) for additional documentation. |
 
 ## Introduction
 

--- a/helm/minio/templates/NOTES.txt
+++ b/helm/minio/templates/NOTES.txt
@@ -12,7 +12,7 @@ Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubec
 
 You can now access MinIO server on http://localhost:9000. Follow the below steps to connect to MinIO server with mc client:
 
-  1. Download the MinIO mc client - https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart
+  1. Download the MinIO mc client - https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart
 
   2. export MC_HOST_{{ template "minio.fullname" . }}_local=http://$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "minio.secretName" . }} -o jsonpath="{.data.rootUser}" | base64 --decode):$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "minio.secretName" . }} -o jsonpath="{.data.rootPassword}" | base64 --decode)@localhost:{{ .Values.service.port }}
 
@@ -27,13 +27,13 @@ Note that the public IP may take a couple of minutes to be available.
 
 You can now access MinIO server on http://<External-IP>:9000. Follow the below steps to connect to MinIO server with mc client:
 
-  1. Download the MinIO mc client - https://docs.min.io/community/minio-object-store/reference/minio-mc.html#quickstart
+  1. Download the MinIO mc client - https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart
 
   2. export MC_HOST_{{ template "minio.fullname" . }}_local=http://$(kubectl get secret {{ template "minio.secretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.rootUser}" | base64 --decode):$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.rootPassword}" | base64 --decode)@<External-IP>:{{ .Values.service.port }}
 
   3. mc ls {{ template "minio.fullname" . }}
 
-Alternately, you can use your browser or the MinIO SDK to access the server - https://docs.min.io/community/minio-object-store/reference/minio-server/minio-server.html
+Alternately, you can use your browser or the MinIO SDK to access the server - https://silo.pigsty.io/community/minio-object-store/reference/minio-server/minio-server.html
 {{- end }}
 
 {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}

--- a/helm/minio/templates/NOTES.txt
+++ b/helm/minio/templates/NOTES.txt
@@ -12,7 +12,7 @@ Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubec
 
 You can now access MinIO server on http://localhost:9000. Follow the below steps to connect to MinIO server with mc client:
 
-  1. Download the MinIO mc client - https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart
+  1. Download the MinIO mc client - https://silo.pigsty.io/reference/minio-mc.html#quickstart
 
   2. export MC_HOST_{{ template "minio.fullname" . }}_local=http://$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "minio.secretName" . }} -o jsonpath="{.data.rootUser}" | base64 --decode):$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "minio.secretName" . }} -o jsonpath="{.data.rootPassword}" | base64 --decode)@localhost:{{ .Values.service.port }}
 
@@ -27,13 +27,13 @@ Note that the public IP may take a couple of minutes to be available.
 
 You can now access MinIO server on http://<External-IP>:9000. Follow the below steps to connect to MinIO server with mc client:
 
-  1. Download the MinIO mc client - https://silo.pigsty.io/community/minio-object-store/reference/minio-mc.html#quickstart
+  1. Download the MinIO mc client - https://silo.pigsty.io/reference/minio-mc.html#quickstart
 
   2. export MC_HOST_{{ template "minio.fullname" . }}_local=http://$(kubectl get secret {{ template "minio.secretName" . }} --namespace {{ .Release.Namespace }} -o jsonpath="{.data.rootUser}" | base64 --decode):$(kubectl get secret {{ template "minio.secretName" . }} -o jsonpath="{.data.rootPassword}" | base64 --decode)@<External-IP>:{{ .Values.service.port }}
 
   3. mc ls {{ template "minio.fullname" . }}
 
-Alternately, you can use your browser or the MinIO SDK to access the server - https://silo.pigsty.io/community/minio-object-store/reference/minio-server/minio-server.html
+Alternately, you can use your browser or the MinIO SDK to access the server - https://silo.pigsty.io/reference/minio-server/minio-server.html
 {{- end }}
 
 {{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -88,7 +88,7 @@ runtimeClassName: ""
 
 ## Set default rootUser, rootPassword
 ## rootUser and rootPassword is generated when not set
-## Distributed MinIO ref: https://docs.min.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html
+## Distributed MinIO ref: https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html
 ##
 rootUser: ""
 rootPassword: ""
@@ -132,7 +132,7 @@ tls:
   publicCrt: public.crt
   privateKey: private.key
 
-## Trusted Certificates Settings for MinIO. Ref: https://docs.min.io/community/minio-object-store/operations/network-encryption.html#third-party-certificate-authorities
+## Trusted Certificates Settings for MinIO. Ref: https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html#third-party-certificate-authorities
 ## Bundle multiple trusted certificates into one secret and pass that here. Ref: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
 ## When using self-signed certificates, remember to include MinIO's own certificate in the bundle with key public.crt.
 ## If certSecret is left empty and tls is enabled, this chart installs the public certificate from .Values.tls.certSecret.
@@ -369,7 +369,7 @@ makePolicyJob:
 users:
   ## Username, password and policy to be assigned to the user
   ## Default policies are [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
-  ## Add new policies as explained here https://docs.min.io/community/minio-object-store/administration/identity-access-management.html#access-management
+  ## Add new policies as explained here https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management.html#access-management
   ## NOTE: this will fail if LDAP is enabled in your MinIO deployment
   ## make sure to disable this if you are using LDAP.
   - accessKey: console
@@ -398,7 +398,7 @@ makeUserJob:
 svcaccts:
   []
   ## accessKey, secretKey and parent user to be assigned to the service accounts
-  ## Add new service accounts as explained here https://docs.min.io/community/minio-object-store/administration/identity-access-management/minio-user-management.html#access-keys
+  ## Add new service accounts as explained here https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/minio-user-management.html#access-keys
   # - accessKey: console-svcacct
   #   secretKey: console123
   #   user: console
@@ -515,7 +515,7 @@ postJob:
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed
 environment:
-  ## Please refer for comprehensive list https://docs.min.io/community/minio-object-store/reference/minio-server/minio-server.html
+  ## Please refer for comprehensive list https://silo.pigsty.io/community/minio-object-store/reference/minio-server/minio-server.html
   ## MINIO_SUBNET_LICENSE: "License key obtained from https://subnet.min.io"
   ## MINIO_BROWSER: "off"
 
@@ -527,7 +527,7 @@ extraSecret: ~
 
 ## OpenID Identity Management
 ## The following section documents environment variables for enabling external identity management using an OpenID Connect (OIDC)-compatible provider.
-## See https://docs.min.io/community/minio-object-store/operations/external-iam/configure-openid-external-identity-management.html for a tutorial on using these variables.
+## See https://silo.pigsty.io/community/minio-object-store/operations/external-iam/configure-openid-external-identity-management.html for a tutorial on using these variables.
 oidc:
   enabled: false
   configUrl: "https://identity-provider-url/.well-known/openid-configuration"

--- a/helm/minio/values.yaml
+++ b/helm/minio/values.yaml
@@ -88,7 +88,7 @@ runtimeClassName: ""
 
 ## Set default rootUser, rootPassword
 ## rootUser and rootPassword is generated when not set
-## Distributed MinIO ref: https://silo.pigsty.io/community/minio-object-store/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html
+## Distributed MinIO ref: https://silo.pigsty.io/operations/install-deploy-manage/deploy-minio-multi-node-multi-drive.html
 ##
 rootUser: ""
 rootPassword: ""
@@ -132,7 +132,7 @@ tls:
   publicCrt: public.crt
   privateKey: private.key
 
-## Trusted Certificates Settings for MinIO. Ref: https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html#third-party-certificate-authorities
+## Trusted Certificates Settings for MinIO. Ref: https://silo.pigsty.io/operations/network-encryption.html#third-party-certificate-authorities
 ## Bundle multiple trusted certificates into one secret and pass that here. Ref: https://github.com/minio/minio/tree/master/docs/tls/kubernetes#2-create-kubernetes-secret
 ## When using self-signed certificates, remember to include MinIO's own certificate in the bundle with key public.crt.
 ## If certSecret is left empty and tls is enabled, this chart installs the public certificate from .Values.tls.certSecret.
@@ -369,7 +369,7 @@ makePolicyJob:
 users:
   ## Username, password and policy to be assigned to the user
   ## Default policies are [readonly|readwrite|writeonly|consoleAdmin|diagnostics]
-  ## Add new policies as explained here https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management.html#access-management
+  ## Add new policies as explained here https://silo.pigsty.io/administration/identity-access-management.html#access-management
   ## NOTE: this will fail if LDAP is enabled in your MinIO deployment
   ## make sure to disable this if you are using LDAP.
   - accessKey: console
@@ -398,7 +398,7 @@ makeUserJob:
 svcaccts:
   []
   ## accessKey, secretKey and parent user to be assigned to the service accounts
-  ## Add new service accounts as explained here https://silo.pigsty.io/community/minio-object-store/administration/identity-access-management/minio-user-management.html#access-keys
+  ## Add new service accounts as explained here https://silo.pigsty.io/administration/identity-access-management/minio-user-management.html#access-keys
   # - accessKey: console-svcacct
   #   secretKey: console123
   #   user: console
@@ -515,7 +515,7 @@ postJob:
 ## Use this field to add environment variables relevant to MinIO server. These fields will be passed on to MinIO container(s)
 ## when Chart is deployed
 environment:
-  ## Please refer for comprehensive list https://silo.pigsty.io/community/minio-object-store/reference/minio-server/minio-server.html
+  ## Please refer for comprehensive list https://silo.pigsty.io/reference/minio-server/minio-server.html
   ## MINIO_SUBNET_LICENSE: "License key obtained from https://subnet.min.io"
   ## MINIO_BROWSER: "off"
 
@@ -527,7 +527,7 @@ extraSecret: ~
 
 ## OpenID Identity Management
 ## The following section documents environment variables for enabling external identity management using an OpenID Connect (OIDC)-compatible provider.
-## See https://silo.pigsty.io/community/minio-object-store/operations/external-iam/configure-openid-external-identity-management.html for a tutorial on using these variables.
+## See https://silo.pigsty.io/operations/external-iam/configure-openid-external-identity-management.html for a tutorial on using these variables.
 oidc:
   enabled: false
   configUrl: "https://identity-provider-url/.well-known/openid-configuration"

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -106,13 +106,13 @@ var (
 	ErrInvalidErasureEndpoints = newErrFn(
 		"Invalid endpoint(s) in erasure mode",
 		"Please provide correct combination of local/remote paths",
-		"For more information, please refer to https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html",
+		"For more information, please refer to https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html",
 	)
 
 	ErrInvalidNumberOfErasureEndpoints = newErrFn(
 		"Invalid total number of endpoints for erasure mode",
 		"Please provide number of endpoints greater or equal to 2",
-		"For more information, please refer to https://docs.min.io/community/minio-object-store/operations/concepts/erasure-coding.html",
+		"For more information, please refer to https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html",
 	)
 
 	ErrStorageClassValue = newErrFn(
@@ -192,7 +192,7 @@ Examples:
 	ErrNoCertsAndHTTPSEndpoints = newErrFn(
 		"HTTPS specified in endpoints, but no TLS certificate is found on the local machine",
 		"Please add TLS certificate or use HTTP endpoints only",
-		"Refer to https://docs.min.io/community/minio-object-store/operations/network-encryption.html for information about how to load a TLS certificate in your server",
+		"Refer to https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html for information about how to load a TLS certificate in your server",
 	)
 
 	ErrCertsAndHTTPEndpoints = newErrFn(

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -106,13 +106,13 @@ var (
 	ErrInvalidErasureEndpoints = newErrFn(
 		"Invalid endpoint(s) in erasure mode",
 		"Please provide correct combination of local/remote paths",
-		"For more information, please refer to https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html",
+		"For more information, please refer to https://silo.pigsty.io/operations/concepts/erasure-coding.html",
 	)
 
 	ErrInvalidNumberOfErasureEndpoints = newErrFn(
 		"Invalid total number of endpoints for erasure mode",
 		"Please provide number of endpoints greater or equal to 2",
-		"For more information, please refer to https://silo.pigsty.io/community/minio-object-store/operations/concepts/erasure-coding.html",
+		"For more information, please refer to https://silo.pigsty.io/operations/concepts/erasure-coding.html",
 	)
 
 	ErrStorageClassValue = newErrFn(
@@ -192,7 +192,7 @@ Examples:
 	ErrNoCertsAndHTTPSEndpoints = newErrFn(
 		"HTTPS specified in endpoints, but no TLS certificate is found on the local machine",
 		"Please add TLS certificate or use HTTP endpoints only",
-		"Refer to https://silo.pigsty.io/community/minio-object-store/operations/network-encryption.html for information about how to load a TLS certificate in your server",
+		"Refer to https://silo.pigsty.io/operations/network-encryption.html for information about how to load a TLS certificate in your server",
 	)
 
 	ErrCertsAndHTTPEndpoints = newErrFn(

--- a/minio.service
+++ b/minio.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=MinIO
-Documentation=https://docs.min.io
+Documentation=https://silo.pigsty.io
 Wants=network-online.target
 After=network-online.target
 AssertFileIsExecutable=/usr/local/bin/minio


### PR DESCRIPTION
## Description
Thanks for the fork, much appreciated!

When I started the forked minio I saw some references to old docs and I just did a mass regexp-replace, from docs.min.io to silo.pigsty.io. This should in the future not have people look at logs and point to the incorrect doc-site:

```
s3-1          | MinIO Object Storage Server
s3-1          | Copyright: 2015-2026 MinIO, Inc.
s3-1          | License: GNU AGPLv3 - https://www.gnu.org/licenses/agpl-3.0.html
s3-1          | Version: RELEASE.2026-06-18T00-00-00Z (go1.26.4 linux/amd64)
s3-1          |
s3-1          | API: http://172.30.0.103:9000  http://192.168.96.15:9000  http://127.0.0.1:9000
s3-1          | WebUI: http://172.30.0.103:9001 http://192.168.96.15:9001 http://127.0.0.1:9001
s3-1          |
s3-1          | Docs: https://docs.min.io
```

In addition, as pigsty doesn't expose `community/minio-object-store/` in the URL, stripped that away as well, so you get nice pages and not CSS-less things.

## Types of changes
- [x] Documentation update

## Checklist:
- [x] Internal documentation updated

If you review this PR, word-diff is advised, makes looking at it a breeze.

As a side note:
Copyright: 2015-2026 MinIO, Inc.

^^ You can add your name here :)