### PR TITLE
fix: reject unsupported checksum assertions

### DIFF
--- a/cmd/object-api-options.go
+++ b/cmd/object-api-options.go
@@ -439,6 +439,9 @@ func putOptsFromHeaders(ctx context.Context, hdr http.Header, metadata map[strin
 
 // get ObjectOptions for Copy calls with encryption headers provided on the target side and source side metadata
 func copyDstOpts(ctx context.Context, r *http.Request, bucket, object string, metadata map[string]string) (opts ObjectOptions, err error) {
+	if _, err := hash.GetContentChecksum(r.Header); err != nil {
+		return opts, err
+	}
 	return putOptsFromReq(ctx, r, bucket, object, metadata)
 }
 

--- a/cmd/object-checksum-unsupported_test.go
+++ b/cmd/object-checksum-unsupported_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio/internal/auth"
+	xhttp "github.com/minio/minio/internal/http"
+)
+
+func TestAPIRejectsUnsupportedChecksumHeaders(t *testing.T) {
+	defer DetectTestLeak(t)()
+	ExecObjectLayerAPITest(ExecObjectLayerAPITestArgs{
+		t:          t,
+		objAPITest: testAPIRejectsUnsupportedChecksumHeaders,
+		endpoints:  []string{"CopyObject", "NewMultipart", "PutObject", "PutObjectPart"},
+	})
+}
+
+func testAPIRejectsUnsupportedChecksumHeaders(obj ObjectLayer, instanceType, bucketName string,
+	apiRouter http.Handler, credentials auth.Credentials, t *testing.T,
+) {
+	data := []byte("unsupported-checksum")
+	unsupportedValue := base64.StdEncoding.EncodeToString(make([]byte, 64))
+
+	put := func(object string, headers map[string]string) *httptest.ResponseRecorder {
+		t.Helper()
+		req, err := newTestSignedRequestV4(http.MethodPut, getPutObjectURL("", bucketName, object),
+			int64(len(data)), bytes.NewReader(data), credentials.AccessKey, credentials.SecretKey, headers)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		apiRouter.ServeHTTP(rec, req)
+		return rec
+	}
+	assertRejected := func(name string, rec *httptest.ResponseRecorder) {
+		t.Helper()
+		if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "<Code>InvalidArgument</Code>") {
+			t.Fatalf("%s: %s returned %d, want InvalidArgument: %s", instanceType, name, rec.Code, rec.Body.String())
+		}
+	}
+
+	for _, algorithm := range []string{"md5", "sha512", "xxhash64", "xxhash3", "xxhash128", "future"} {
+		object := "checksums/unsupported-" + algorithm
+		assertRejected(algorithm, put(object, map[string]string{
+			"x-amz-sdk-checksum-algorithm": "SHA512",
+			"x-amz-checksum-" + algorithm:  unsupportedValue,
+		}))
+		if _, err := obj.GetObjectInfo(t.Context(), bucketName, object, ObjectOptions{}); !isErrObjectNotFound(err) {
+			t.Fatalf("%s: rejected %s checksum stored an object: %v", instanceType, algorithm, err)
+		}
+	}
+
+	assertRejected("unsupported trailer", put("checksums/unsupported-trailer", map[string]string{
+		xhttp.AmzTrailer: "x-amz-checksum-sha512",
+	}))
+
+	newMultipart := func(name string, headers map[string]string) *httptest.ResponseRecorder {
+		t.Helper()
+		req, err := newTestSignedRequestV4(http.MethodPost, getNewMultipartURL("", bucketName, name),
+			0, nil, credentials.AccessKey, credentials.SecretKey, headers)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		apiRouter.ServeHTTP(rec, req)
+		return rec
+	}
+	assertRejected("NewMultipartUpload value header", newMultipart("checksums/mp-value", map[string]string{
+		"x-amz-checksum-sha512": unsupportedValue,
+	}))
+	assertRejected("NewMultipartUpload trailer", newMultipart("checksums/mp-trailer", map[string]string{
+		xhttp.AmzTrailer: "x-amz-checksum-sha512",
+	}))
+
+	rec := newMultipart("checksums/mp-part", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s: NewMultipartUpload setup returned %d: %s", instanceType, rec.Code, rec.Body.String())
+	}
+	var initiated InitiateMultipartUploadResponse
+	if err := xml.Unmarshal(rec.Body.Bytes(), &initiated); err != nil {
+		t.Fatal(err)
+	}
+	req, err := newTestSignedRequestV4(http.MethodPut,
+		getPutObjectPartURL("", bucketName, "checksums/mp-part", initiated.UploadID, "1"),
+		int64(len(data)), bytes.NewReader(data), credentials.AccessKey, credentials.SecretKey,
+		map[string]string{"x-amz-checksum-sha512": unsupportedValue})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec = httptest.NewRecorder()
+	apiRouter.ServeHTTP(rec, req)
+	assertRejected("UploadPart", rec)
+	parts, err := obj.ListObjectParts(t.Context(), bucketName, "checksums/mp-part", initiated.UploadID, 0, 1000, ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parts.Parts) != 0 {
+		t.Fatalf("%s: rejected UploadPart stored %d parts", instanceType, len(parts.Parts))
+	}
+	if err := obj.AbortMultipartUpload(t.Context(), bucketName, "checksums/mp-part", initiated.UploadID, ObjectOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	source := "checksums/source"
+	putCopyChecksumSource(t, apiRouter, credentials, bucketName, source, data, nil)
+	rec = copyChecksumRequest(t, apiRouter, credentials, bucketName, source, "checksums/copy", map[string]string{
+		"x-amz-checksum-sha512": unsupportedValue,
+	})
+	assertRejected("CopyObject", rec)
+	if _, err := obj.GetObjectInfo(t.Context(), bucketName, "checksums/copy", ObjectOptions{}); !isErrObjectNotFound(err) {
+		t.Fatalf("%s: rejected CopyObject stored a destination: %v", instanceType, err)
+	}
+}

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -309,6 +309,10 @@ func (api objectAPIHandlers) NewMultipartUploadHandler(w http.ResponseWriter, r 
 		}
 	}
 
+	if _, err := hash.GetContentChecksum(r.Header); err != nil {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidChecksum), r.URL)
+		return
+	}
 	checksumType := hash.NewChecksumHeader(r.Header)
 	if checksumType.Is(hash.ChecksumInvalid) {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrInvalidChecksum), r.URL)

--- a/internal/hash/checksum.go
+++ b/internal/hash/checksum.go
@@ -657,22 +657,55 @@ func AddChecksumHeader(w http.ResponseWriter, c map[string]string) {
 	}
 }
 
+func isSupportedChecksumHeader(name string) bool {
+	switch {
+	case strings.EqualFold(name, xhttp.AmzChecksumAlgo),
+		strings.EqualFold(name, xhttp.AmzChecksumType),
+		strings.EqualFold(name, xhttp.AmzChecksumMode):
+		return true
+	}
+	for _, checksumType := range BaseChecksumTypes {
+		if strings.EqualFold(name, checksumType.Key()) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUnsupportedChecksumHeader(h http.Header) bool {
+	for name := range h {
+		if strings.HasPrefix(strings.ToLower(name), "x-amz-checksum-") && !isSupportedChecksumHeader(name) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetContentChecksum returns content checksum.
 // Returns ErrInvalidChecksum if so.
 // Returns nil, nil if no checksum.
 func GetContentChecksum(h http.Header) (*Checksum, error) {
+	if hasUnsupportedChecksumHeader(h) {
+		return nil, ErrInvalidChecksum
+	}
 	if trailing := h.Values(xhttp.AmzTrailer); len(trailing) > 0 {
 		var res *Checksum
-		for _, header := range trailing {
-			var duplicates bool
-			for _, t := range BaseChecksumTypes {
-				if strings.EqualFold(t.Key(), header) {
-					duplicates = res != nil
-					res = NewChecksumWithType(t|ChecksumTrailing, "")
+		for _, headers := range trailing {
+			for header := range strings.SplitSeq(headers, ",") {
+				header = strings.TrimSpace(header)
+				var duplicates bool
+				for _, t := range BaseChecksumTypes {
+					if strings.EqualFold(t.Key(), header) {
+						duplicates = res != nil
+						res = NewChecksumWithType(t|ChecksumTrailing, "")
+					}
 				}
-			}
-			if duplicates {
-				return nil, ErrInvalidChecksum
+				if strings.HasPrefix(strings.ToLower(header), "x-amz-checksum-") && !isSupportedChecksumHeader(header) {
+					return nil, ErrInvalidChecksum
+				}
+				if duplicates {
+					return nil, ErrInvalidChecksum
+				}
 			}
 		}
 		if res != nil {

--- a/internal/hash/checksum_test.go
+++ b/internal/hash/checksum_test.go
@@ -18,11 +18,52 @@
 package hash
 
 import (
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	xhttp "github.com/minio/minio/internal/http"
 )
+
+func TestGetContentChecksumRejectsUnsupportedHeaders(t *testing.T) {
+	unsupported := []string{
+		"x-amz-checksum-md5",
+		"x-amz-checksum-sha512",
+		"x-amz-checksum-xxhash64",
+		"x-amz-checksum-xxhash3",
+		"x-amz-checksum-xxhash128",
+		"x-amz-checksum-future",
+	}
+	for _, header := range unsupported {
+		t.Run("header/"+header, func(t *testing.T) {
+			h := http.Header{header: {"AA=="}}
+			if _, err := GetContentChecksum(h); !errors.Is(err, ErrInvalidChecksum) {
+				t.Fatalf("GetContentChecksum(%s) error = %v, want ErrInvalidChecksum", header, err)
+			}
+		})
+		t.Run("trailer/"+header, func(t *testing.T) {
+			h := http.Header{xhttp.AmzTrailer: {header}}
+			if _, err := GetContentChecksum(h); !errors.Is(err, ErrInvalidChecksum) {
+				t.Fatalf("GetContentChecksum(trailer %s) error = %v, want ErrInvalidChecksum", header, err)
+			}
+		})
+	}
+
+	for header, value := range map[string]string{
+		xhttp.AmzChecksumAlgo:          "CRC32",
+		xhttp.AmzChecksumType:          xhttp.AmzChecksumTypeComposite,
+		xhttp.AmzChecksumMode:          "ENABLED",
+		"x-amz-sdk-checksum-algorithm": "SHA512",
+	} {
+		t.Run("control/"+header, func(t *testing.T) {
+			h := http.Header{header: {value}}
+			if _, err := GetContentChecksum(h); errors.Is(err, ErrInvalidChecksum) {
+				t.Fatalf("control header %s was rejected", header)
+			}
+		})
+	}
+}
 
 // TestChecksumAddToHeader tests that adding and retrieving a checksum on a header works
 func TestChecksumAddToHeader(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject unimplemented MD5, SHA512, XXHASH64, XXHASH3, XXHASH128, future value headers, and trailer names
- preserve the five implemented algorithms and SDK control headers
- enforce the contract across PutObject, multipart initiation/parts, CopyObject, and UploadPartCopy
- parse comma-separated trailer declarations and reject duplicate checksum trailers

## Validation

- internal header/trailer allowlist matrix
- HTTP mutation/non-creation tests on both backends
- focused normal/race and `go vet` for hash/cmd
- Claude Opus 5 Max review with missing multipart call sites added

Unsupported cross-vendor replication now fails visibly instead of silently dropping an integrity assertion. Documentation is in pgsty/silo.pgsty.com PR #9.
