### PR TITLE
fix: reject composite CRC64NVME completion

### DIFF
--- a/cmd/erasure-multipart-fullobject_test.go
+++ b/cmd/erasure-multipart-fullobject_test.go
@@ -516,7 +516,7 @@ func testAPICompleteMultipartChecksumTypeMismatch(obj ObjectLayer, instanceType,
 		}
 	})
 
-	t.Run("crc64nvme-composite-remains-canonicalized", func(t *testing.T) {
+	t.Run("crc64nvme-composite-completion-is-rejected", func(t *testing.T) {
 		crc64Type := hash.ChecksumCRC64NVME
 		objectName := "type-mismatch/crc64nvme-composite"
 		uploadID := newMultipartUploadHTTP(t, apiRouter, credentials, bucketName, objectName,
@@ -527,8 +527,11 @@ func testAPICompleteMultipartChecksumTypeMismatch(obj ObjectLayer, instanceType,
 				crc64Type.Key():       mustChecksum(t, crc64Type, full),
 				xhttp.AmzChecksumType: xhttp.AmzChecksumTypeComposite,
 			})
-		if rec.Code != http.StatusOK {
-			t.Fatalf("%s: CRC64NVME canonicalization changed: %d %s", instanceType, rec.Code, rec.Body.String())
+		if rec.Code != http.StatusBadRequest || apiErrorCode(t, rec) != "BadDigest" {
+			t.Fatalf("%s: CRC64NVME composite completion returned %d %s", instanceType, rec.Code, rec.Body.String())
+		}
+		if _, err := obj.GetObjectInfo(t.Context(), bucketName, objectName, ObjectOptions{}); err == nil {
+			t.Fatalf("%s: object was created despite a rejected CRC64NVME checksum type", instanceType)
 		}
 	})
 }

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -1185,13 +1185,7 @@ func (er erasureObjects) CompleteMultipartUpload(ctx context.Context, bucket str
 			}
 		}
 		if opts.wantChecksumType != "" {
-			providedObjectType := opts.wantChecksumType
-			// CRC64NVME is always canonicalized to FULL_OBJECT. Preserve this
-			// behavior until its exact AWS wire semantics have been probed.
-			if checksumType.Base().Is(hash.ChecksumCRC64NVME) {
-				providedObjectType = xhttp.AmzChecksumTypeFullObject
-			}
-			if providedObjectType != expectedType.ObjType() {
+			if opts.wantChecksumType != expectedType.ObjType() {
 				return oi, completeMultipartChecksumTypeMismatch(opts.wantChecksumType, expectedType.ObjType())
 			}
 		}


### PR DESCRIPTION
## Summary

- remove the last CompleteMultipartUpload carve-out that silently converted an explicit CRC64NVME `COMPOSITE` type to `FULL_OBJECT`
- return the existing checksum-type mismatch error before creating the object
- preserve upgrade safety because legacy in-flight CRC64NVME uploads already store `FULL_OBJECT` metadata

## Dependency

Stacked on foundation PR #85, which introduced the explicit type-only validation seam.

## Validation

- focused normal/race
- `go vet ./cmd`
- object non-creation assertion

This complements checksum-contract PR #92 and issue #50 PR #93; after all three land, initiation, PutObject, streaming trailers, and completion reject CRC64NVME plus `COMPOSITE` consistently.
