### PR TITLE
fix: return 500 for unreadable objects instead of 206

### DIFF
--- a/cmd/api-errors.go
+++ b/cmd/api-errors.go
@@ -1523,10 +1523,14 @@ var errorCodes = errorCodeMap{
 		Description:    "Your Host header is malformed.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
+	// The stored object cannot be served: a server-side data condition, not a
+	// successful partial read. Upstream maps it to http.StatusPartialContent
+	// (since ca6b4773e, 2017), which lets SDKs accept the XML error document
+	// as object content; SILO deliberately diverges and returns 500.
 	ErrObjectTampered: {
 		Code:           "XMinioObjectTampered",
 		Description:    errObjectTampered.Error(),
-		HTTPStatusCode: http.StatusPartialContent,
+		HTTPStatusCode: http.StatusInternalServerError,
 	},
 
 	ErrSiteReplicationInvalidRequest: {

--- a/cmd/object-handlers_tampered_test.go
+++ b/cmd/object-handlers_tampered_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio/internal/auth"
+	"github.com/minio/minio/internal/crypto"
+)
+
+// tamperedObjectLayer returns a fixed error from the read paths so the handler
+// response can be tested without reproducing the storage defect that produces
+// an unreadable object. No object bytes are sent to the caller.
+type tamperedObjectLayer struct {
+	ObjectLayer
+	err error
+}
+
+func (o *tamperedObjectLayer) GetObjectNInfo(context.Context, string, string, *HTTPRangeSpec, http.Header, ObjectOptions) (*GetObjectReader, error) {
+	return nil, o.err
+}
+
+func (o *tamperedObjectLayer) GetObjectInfo(context.Context, string, string, ObjectOptions) (ObjectInfo, error) {
+	return ObjectInfo{}, o.err
+}
+
+// TestObjectTamperedGETHEADStatus asserts that an object the server cannot
+// decode is reported with a 5xx status, not a success status. Returning
+// http.StatusPartialContent here let SDKs accept the XML error document as
+// object content. See pgsty/silo#110.
+func TestObjectTamperedGETHEADStatus(t *testing.T) {
+	ExecObjectLayerAPITest(ExecObjectLayerAPITestArgs{t: t, objAPITest: func(obj ObjectLayer, instanceType, bucket string, router http.Handler, credentials auth.Credentials, t *testing.T) {
+		// An encrypted stream shorter than one complete encryption package is
+		// a real size-validation origin of errObjectTampered.
+		damaged := ObjectInfo{Size: 31, UserDefined: map[string]string{crypto.MetaAlgorithm: crypto.InsecureSealAlgorithm}}
+		_, err := damaged.DecryptedSize()
+		if err != errObjectTampered {
+			t.Fatalf("damaged-size error = %v, want errObjectTampered", err)
+		}
+		previous := newObjectLayerFn()
+		setObjectLayer(&tamperedObjectLayer{ObjectLayer: obj, err: err})
+		defer setObjectLayer(previous)
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			req, err := newTestSignedRequestV4(method, getGetObjectURL("", bucket, "damaged-object"), 0, nil, credentials.AccessKey, credentials.SecretKey, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if method == http.MethodGet && !strings.Contains(rec.Body.String(), "<Code>XMinioObjectTampered</Code>") {
+				t.Fatalf("%s: GET did not reach the damaged-object response: %d %s", instanceType, rec.Code, rec.Body.String())
+			}
+			if method == http.MethodHead && rec.Header().Get(xMinIOErrCodeHeader) != "XMinioObjectTampered" {
+				t.Fatalf("%s: HEAD did not reach the damaged-object response: %d %v", instanceType, rec.Code, rec.Header())
+			}
+			if rec.Code != http.StatusInternalServerError {
+				t.Errorf("%s: %s of a damaged object returned HTTP %d, want %d", instanceType, method, rec.Code, http.StatusInternalServerError)
+			}
+		}
+	}})
+}


### PR DESCRIPTION
## Contribution Licensing (no CLA, inbound=outbound, DCO required)

This project does not use a CLA; contributions are accepted inbound=outbound.
By submitting this pull request I represent that I have the right to contribute
the changes, which are licensed under this repository's
[GNU Affero General Public License v3.0 or later](https://www.gnu.org/licenses/agpl-3.0.html)
and remain my copyright. Every commit carries a DCO `Signed-off-by` trailer.

## Description

`ErrObjectTampered` was mapped to HTTP 206 Partial Content, so a GET or HEAD of an object the server cannot decode answered with a success status and an XML error document that SDKs handed back as object content (boto3 returned the XML as `Body`, and a zero-length HEAD as success). This maps the entry to 500 Internal Server Error, keeping the `XMinioObjectTampered` code and message, and adds a signed GET/HEAD regression test on both object-layer backends.

Fixes #110. Fix plan agreed with the Codex reviewer: https://github.com/pgsty/silo/issues/110#issuecomment-5549401400. Adversarial Codex review of this implementation: round 1 FAIL (the plan's live acceptance check had not been run), round 2 PASS with no findings after the live replay below.

## Motivation and Context

Every origin of `errObjectTampered` (`cmd/encryption-v1.go` size validation, `cmd/object-api-utils.go` actual-size metadata, the multipart ETag shape check) is a stored-state defect, not caller input, so a 5xx is the honest class and lets clients raise an error instead of saving an error document as data. The 206 entry is inherited unchanged from upstream `ca6b4773e` (2017), which added nine SSE entries at once with the other eight at 400; upstream `master` still carries 206, so this is a deliberate divergence, recorded in the code comment and to be noted in the release fix note on silo.pgsty.com.

## How to test this PR?

```
GOWORK=off go test -tags kqueue,dev ./cmd -run '^(TestObjectTamperedGETHEADStatus|TestAPIErrCode|TestAPIErrCodeDefinition|TestAPIHeadObjectHandler|TestAPIHeadObjectHandlerWithEncryption|TestAPIGetObjectHandler)$' -count=1 -v
```

With the product hunk reverted, `TestObjectTamperedGETHEADStatus` fails with `GET of a damaged object returned HTTP 206, want 500` (and HEAD) on ErasureSD and Erasure; with the fix all six tests pass. `gofmt -l cmd` is empty; `golangci-lint run --build-tags kqueue --config ./.golangci.yml ./cmd/...` reports 0 issues.

Live replay (the plan's acceptance check): the destination data directory of the 2026-09-05 review lab, which holds the original unreadable SSE-C replica (`review-ssec-plain-cbebf0/ssec-size-131072.txt`, compressed ciphertext), was copied and served over loopback TLS by two binaries in turn; boto3 1.43.89 issued HEAD and GET with the original customer key.

| Binary | HEAD | GET |
| --- | --- | --- |
| This branch (5703426b3) | `ClientError` 500 | `ClientError` 500 `XMinioObjectTampered` |
| Published `RELEASE.2026-09-03T13-18-01Z` | returned normally, 206, `Content-Length: 0` | returned normally, 206, 429-byte error XML as `Body` |

Controls were identical on both binaries: the default-SSE-S3 bucket's replica still answers 400 `InvalidRequest`, and a healthy object answers 200 with its bytes. Script, result files and server logs are archived on the maintainer's machine under `/Users/vonng/pgsty/silo-codex-triage-20260905/silo-110/live-replay/`.

## Compatibility impact

Only the HTTP status of one MinIO-specific error code changes; response body, headers and every healthy-object path are unchanged. No client in pgsty/mc, pgsty/silo-console or pgsty/silo-pkg special-cases `XMinioObjectTampered`. Clients now treat damaged-object reads as retryable 5xx (minio-go and boto3 standard mode retry 500), bounded by their retry configuration. Damaged-object reads count as 5xx in metrics and audit logs from now on. Diverges from upstream `minio/minio` master, which still returns 206.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [ ] Fixes a regression (inherited from upstream `ca6b4773e`, not a SILO regression)
- [x] Unit tests added/updated
- [x] `make verifiers` equivalent: gofmt clean, golangci-lint 0 issues on `./cmd/...`
- [x] Relevant package tests pass
- [x] Compatibility and rollback impact documented
- [x] Internal documentation updated (code comment records the upstream divergence)
- [ ] Public documentation update opened in `pgsty/silo.pgsty.com` (release fix note, to follow with the release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe
