### PR TITLE
fix: preserve plaintext sizes for replicated SSE-C parts

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -212,7 +212,10 @@ func setObjectHeaders(ctx context.Context, w http.ResponseWriter, objInfo Object
 	}
 
 	if rs == nil && opts.PartNumber > 0 {
-		rs = partNumberToRangeSpec(objInfo, opts.PartNumber)
+		rs, err = partNumberToRangeSpec(objInfo, opts.PartNumber)
+		if err != nil {
+			return err
+		}
 	}
 
 	// For providing ranged content

--- a/cmd/erasure-multipart.go
+++ b/cmd/erasure-multipart.go
@@ -710,19 +710,20 @@ func (er erasureObjects) PutObjectPart(ctx context.Context, bucket, object, uplo
 	}
 
 	actualSize := data.ActualSize()
-	if actualSize < 0 {
-		_, encrypted := crypto.IsEncrypted(fi.Metadata)
-		compressed := fi.IsCompressed()
+	_, encrypted := crypto.IsEncrypted(fi.Metadata)
+	compressed := fi.IsCompressed()
+	if encrypted && !compressed {
+		decSize, err := sio.DecryptedSize(uint64(n))
+		if err != nil {
+			return pi, errObjectTampered
+		}
+		actualSize = int64(decSize)
+	} else if actualSize < 0 {
 		switch {
 		case compressed:
 			// ... nothing changes for compressed stream.
 			// if actualSize is -1 we have no known way to
 			// determine what is the actualSize.
-		case encrypted:
-			decSize, err := sio.DecryptedSize(uint64(n))
-			if err == nil {
-				actualSize = int64(decSize)
-			}
 		default:
 			actualSize = n
 		}

--- a/cmd/object-api-utils.go
+++ b/cmd/object-api-utils.go
@@ -49,6 +49,7 @@ import (
 	xhttp "github.com/minio/minio/internal/http"
 	xioutil "github.com/minio/minio/internal/ioutil"
 	"github.com/minio/minio/internal/logger"
+	"github.com/minio/sio"
 	"github.com/pgsty/silo-pkg/v3/trie"
 	"github.com/pgsty/silo-pkg/v3/wildcard"
 	"github.com/valyala/bytebufferpool"
@@ -675,19 +676,29 @@ func getPartFile(entriesTrie *trie.Trie, partNumber int, etag string) (partFile 
 	return partFile
 }
 
-func partNumberToRangeSpec(oi ObjectInfo, partNumber int) *HTTPRangeSpec {
+func partNumberToRangeSpec(oi ObjectInfo, partNumber int) (*HTTPRangeSpec, error) {
 	if oi.Size == 0 || len(oi.Parts) == 0 {
-		return nil
+		return nil, nil
 	}
 
+	_, encrypted := crypto.IsEncrypted(oi.UserDefined)
+	compressed := oi.IsCompressed()
 	var start int64
 	end := int64(-1)
 	for i := 0; i < len(oi.Parts) && i < partNumber; i++ {
 		start = end + 1
-		end = start + oi.Parts[i].ActualSize - 1
+		partSize := oi.Parts[i].ActualSize
+		if encrypted && !compressed {
+			decSize, err := sio.DecryptedSize(uint64(oi.Parts[i].Size))
+			if err != nil {
+				return nil, errObjectTampered
+			}
+			partSize = int64(decSize)
+		}
+		end = start + partSize - 1
 	}
 
-	return &HTTPRangeSpec{Start: start, End: end}
+	return &HTTPRangeSpec{Start: start, End: end}, nil
 }
 
 // Returns the compressed offset which should be skipped.
@@ -806,7 +817,10 @@ func NewGetObjectReader(rs *HTTPRangeSpec, oi ObjectInfo, opts ObjectOptions, h 
 	}
 
 	if rs == nil && opts.PartNumber > 0 {
-		rs = partNumberToRangeSpec(oi, opts.PartNumber)
+		rs, err = partNumberToRangeSpec(oi, opts.PartNumber)
+		if err != nil {
+			return nil, 0, 0, err
+		}
 	}
 
 	_, isEncrypted := crypto.IsEncrypted(oi.UserDefined)

--- a/cmd/object-api-utils_test.go
+++ b/cmd/object-api-utils_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/minio/minio/internal/auth"
 	"github.com/minio/minio/internal/config/compress"
 	"github.com/minio/minio/internal/crypto"
+	"github.com/minio/sio"
 	"github.com/pgsty/silo-pkg/v3/trie"
 )
 
@@ -658,6 +659,46 @@ func TestGetActualSize(t *testing.T) {
 			t.Errorf("Test %d - expected %d but received %d",
 				i+1, test.result, got)
 		}
+	}
+}
+
+func TestPartNumberToRangeSpecUsesDecryptedPartSizes(t *testing.T) {
+	const plaintextPartSize = int64(5 * 1024 * 1024)
+
+	encryptedSize := func(size int64) int64 {
+		encrypted, err := sio.EncryptedSize(uint64(size))
+		if err != nil {
+			t.Fatalf("failed to calculate encrypted size: %v", err)
+		}
+		return int64(encrypted)
+	}
+
+	info := ObjectInfo{
+		Size: plaintextPartSize * 2,
+		UserDefined: map[string]string{
+			crypto.MetaAlgorithm: crypto.InsecureSealAlgorithm,
+			crypto.MetaMultipart: "1",
+		},
+		Parts: []ObjectPartInfo{
+			{Size: encryptedSize(plaintextPartSize), ActualSize: encryptedSize(plaintextPartSize)},
+			{Size: encryptedSize(plaintextPartSize), ActualSize: encryptedSize(plaintextPartSize)},
+		},
+	}
+
+	rs, err := partNumberToRangeSpec(info, 2)
+	if err != nil {
+		t.Fatalf("partNumberToRangeSpec returned an unexpected error: %v", err)
+	}
+	if got, want := rs.Start, plaintextPartSize; got != want {
+		t.Fatalf("part range start = %d, want %d", got, want)
+	}
+	if got, want := rs.End, plaintextPartSize*2-1; got != want {
+		t.Fatalf("part range end = %d, want %d", got, want)
+	}
+
+	info.Parts[0].Size = 1
+	if _, err := partNumberToRangeSpec(info, 1); err != errObjectTampered {
+		t.Fatalf("invalid encrypted part error = %v, want %v", err, errObjectTampered)
 	}
 }
 

--- a/cmd/object-handlers_test.go
+++ b/cmd/object-handlers_test.go
@@ -979,7 +979,10 @@ func testAPIGetObjectWithPartNumberHandler(obj ObjectLayer, instanceType, bucket
 			t.Fatalf("Object: %s Object Index %d: Unexpected err: %v", object, oindex, err)
 		}
 
-		rs := partNumberToRangeSpec(oinfo, partNumber)
+		rs, err := partNumberToRangeSpec(oinfo, partNumber)
+		if err != nil {
+			t.Fatalf("Object: %s Object Index %d: Unexpected part range err: %v", object, oindex, err)
+		}
 		size, err := oinfo.GetActualSize()
 		if err != nil {
 			t.Fatalf("Object: %s Object Index %d: Unexpected err: %v", object, oindex, err)

--- a/cmd/replication-trust_test.go
+++ b/cmd/replication-trust_test.go
@@ -815,6 +815,16 @@ func testAPISSECMultipartReplicationTrust(obj ObjectLayer, instanceType, bucketN
 	if replCompleteRec.Code != http.StatusOK {
 		t.Fatalf("replica Complete status %d: %s", replCompleteRec.Code, replCompleteRec.Body.String())
 	}
+	replicaInfo, err := obj.GetObjectInfo(t.Context(), bucketName, object, ObjectOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(replicaInfo.Parts) != 1 {
+		t.Fatalf("replicated SSE-C multipart object has %d parts, want 1", len(replicaInfo.Parts))
+	}
+	if got, want := replicaInfo.Parts[0].ActualSize, int64(len(data)); got != want {
+		t.Fatalf("replicated SSE-C part actual size = %d, want plaintext size %d", got, want)
+	}
 
 	getReq, err := newTestSignedRequestV4(http.MethodGet, getGetObjectURL("", bucketName, object),
 		0, nil, credentials.AccessKey, credentials.SecretKey, sseHeaders)
@@ -828,6 +838,21 @@ func testAPISSECMultipartReplicationTrust(obj ObjectLayer, instanceType, bucketN
 	}
 	if !bytes.Equal(getRec.Body.Bytes(), data) {
 		t.Fatal("replicated SSE-C multipart object did not decrypt to source plaintext")
+	}
+
+	partGetReq, err := newTestSignedRequestV4(http.MethodGet,
+		getGetObjectURL("", bucketName, object)+"?partNumber=1", 0, nil,
+		credentials.AccessKey, credentials.SecretKey, sseHeaders)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partGetRec := httptest.NewRecorder()
+	apiRouter.ServeHTTP(partGetRec, partGetReq)
+	if partGetRec.Code != http.StatusPartialContent {
+		t.Fatalf("replicated SSE-C part GET status %d, want %d: %s", partGetRec.Code, http.StatusPartialContent, partGetRec.Body.String())
+	}
+	if !bytes.Equal(partGetRec.Body.Bytes(), data) {
+		t.Fatal("replicated SSE-C part GET did not decrypt to source plaintext")
 	}
 }
 


### PR DESCRIPTION
## Description

Preserve plaintext part sizes when trusted replication uploads already-encrypted SSE-C multipart bytes.

## Motivation

Trusted replication sends the ciphertext bytes unchanged. The receiving `PutObjectPart` path previously kept the ciphertext length whenever the reader already supplied an `ActualSize`, which poisoned replica part metadata. Part-number GETs, HEAD responses, and later data movement could then use ciphertext lengths as plaintext offsets.

This change derives `ActualSize` from `sio.DecryptedSize(part.Size)` for every uncompressed encrypted part before committing the part, returns `XMinioObjectTampered` for invalid encrypted streams, and derives the same plaintext sizes when building part-number ranges. Compressed streams retain their existing behavior.

## How to test

- `go test ./cmd -run 'TestAPISSECMultipartReplicationTrust|TestPartNumberToRangeSpecUsesDecryptedPartSizes|TestAPIGetObjectWithPartNumberHandler' -count=1`
- `go test ./cmd -count=1` (the two existing Windows path/whitespace tests fail independently: `TestIsVolumeRootAlias` and `TestStorageRESTLegitimateOpsStillWork`)
- `go test ./internal/... -count=1` (the existing concurrent-order assertion `internal/store.TestMixedPutGets` is nondeterministic on this environment)
- `go build ./...`
- `go vet ./...`
- `git diff --check`

## Compatibility impact

No metadata rewrite is performed. Existing compressed and unencrypted multipart behavior is unchanged; encrypted part ranges are corrected from the stored ciphertext size.

## Types of changes

- [x] Bug fix
- [x] Unit/integration regression tests

Fixes #119.