### PR TITLE
docs: describe the startup readiness window of the health probes

### DIFF
--- a/docs/metrics/healthcheck/README.md
+++ b/docs/metrics/healthcheck/README.md
@@ -50,7 +50,7 @@ livenessProbe:
 
 ## Readiness probe
 
-This probe always responds with '200 OK'. Only fails if 'etcd' is configured and unreachable. When readiness probe fails, Kubernetes like platforms turn-off routing to the container.
+This probe responds with '200 OK' once the server process is up: it fails only while the request queue is overloaded, or when the health operation against the configured KMS or 'etcd' fails. When readiness probe fails, Kubernetes like platforms turn-off routing to the container.
 
 ```
 readinessProbe:
@@ -120,3 +120,9 @@ X-Xss-Protection: 1; mode=block
 X-Minio-Write-Quorum: 3
 Date: Tue, 21 Jul 2020 00:35:43 GMT
 ```
+
+## Startup readiness window
+
+None of the probes above, and no `admin info` view, proves that the node which received the request can already serve the data path after a restart. Each node connects its erasure drives to its peers in a monitor loop: a remote drive that could not be connected during startup stays uninstalled on that node until a later pass, and the monitor waits 15 seconds after each completed pass, so that interval is a floor between attempts, not a bound on recovery. While a drive is uninstalled, the node's own liveness and readiness probes answer '200 OK', the cluster probes can report healthy as well, because they aggregate every peer's report of its own local drives rather than the drives this node has installed, and `mcli ready` inherits the same blind spot. Yet a PUT through that node can fail with '503 SlowDownWrite' for lack of write quorum, and a GET through it of an object that another node just wrote can answer '404 NoSuchKey'. In the review runs that established this, sampled I/O began succeeding roughly 13 to 15 seconds after the administrative views became healthy on a four-node loopback cluster, consistent with the reconnect interval, and every object acknowledged by other nodes during the window was readable afterwards; these are observations, not guarantees, since reconnection can keep failing.
+
+Automation that restarts a cluster and then immediately writes to it, such as an upgrade or failover runbook, should therefore gate on a bounded data-path check rather than on these probes: one small PUT through each node followed by a read of each object through every node, repeated until every request returns the correct bytes and the acknowledged version within one fixed deadline, with each request budgeted from the remaining deadline and SDK retries disabled, and with the acknowledged objects re-read afterwards. Record the time to first usable I/O separately from the probe result. Such a check proves sampled I/O at that moment for the erasure sets those keys hash to; it proves neither that every set is complete nor that there is headroom for a further node loss, since a set can admit writes with fewer than all of its drives installed. The probes remain the right signal for their stated purpose, process liveness and quorum membership, and are unchanged.


### PR DESCRIPTION
## Contribution Licensing (no CLA, inbound=outbound, DCO required)

This project does not use a CLA; contributions are accepted inbound=outbound.
By submitting this pull request I represent that I have the right to contribute
the changes, which are licensed under this repository's
[GNU Affero General Public License v3.0 or later](https://www.gnu.org/licenses/agpl-3.0.html)
and remain my copyright. Every commit carries a DCO `Signed-off-by` trailer.

## Description

Documentation only. `docs/metrics/healthcheck/README.md` gains a "Startup readiness window" section and a corrected readiness-probe description. After a restart, a node's remote erasure drives that could not be connected during startup stay uninstalled until the next `connectDisks` pass (about 15 seconds); during that window the liveness, readiness and both cluster probes answer 200, `admin info` shows every drive online and `mcli ready` agrees, because the cluster probes aggregate each peer's report of its own local drives rather than the drives the receiving node has installed, yet a PUT through that node can fail with 503 `SlowDownWrite` and a cross-node GET can answer 404 `NoSuchKey`. The section documents the window and the bounded data-path check that restart automation should use instead of the probes.

Refs #116 (the issue stays open for the bounded Linux verification). Plan agreed with the Codex reviewer: https://github.com/pgsty/silo/issues/116#issuecomment-5549418342. Adversarial Codex review of this change (D1): PASS on the documentation ("D1 now conforms"); the harness canary (H1, a review-lab script, not in this repo) is being hardened separately and its deadline-enforcement is escalated to the maintainer.

## Motivation and Context

The behaviour is inherited from upstream and reproduces on the 0806 and 0903 releases alike; the agreed plan judged a product change (probe semantics or reconnect cadence) unproven tuning and chose documentation plus a harness gate. Measured with the review harness on a four-node loopback cluster: time to first usable I/O after a full restart 13.9 s, after single-node restarts 13.6 s, 14.8 s and 14.6 s for three of the four nodes (0.1 s for the other two), with every acknowledged object retained.

## How to test this PR?

Docs only; render the Markdown. The claims are traced to `cmd/healthcheck-handler.go` (`ReadinessCheckHandler`, `ClusterCheckHandler`), `cmd/erasure-server-pool.go` (`Health`, `StorageInfo`), `cmd/notification.go` (`StorageInfo` aggregation), `cmd/erasure.go` (local-endpoint filter), `cmd/erasure-sets.go` (`connectDisks`, `monitorAndConnectEndpoints`, 15 s interval) and `cmd/erasure-object.go` (write-quorum rejection).

## Compatibility impact

None; no product change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [ ] Fixes a regression (not a regression; inherited behaviour)
- [ ] Unit tests added/updated (not applicable)
- [x] Internal documentation updated
- [x] Public documentation update opened in `pgsty/silo.pgsty.com` (companion PR on the site repository)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe
