### PR TITLE
fix: report effective bucket quotas in metrics

### DIFF
--- a/cmd/bucket-quota.go
+++ b/cmd/bucket-quota.go
@@ -43,6 +43,17 @@ func NewBucketQuotaSys() *BucketQuotaSys {
 	return &BucketQuotaSys{}
 }
 
+// getBucketQuotaSize returns the effective enforced hard-quota size.
+func getBucketQuotaSize(quota *madmin.BucketQuota) uint64 {
+	if quota == nil || quota.Type != madmin.HardQuota {
+		return 0
+	}
+	if quota.Size > 0 {
+		return quota.Size
+	}
+	return quota.Quota
+}
+
 var bucketStorageCache = cachevalue.New[DataUsageInfo]()
 
 // Init initialize bucket quota.
@@ -110,14 +121,7 @@ func (sys *BucketQuotaSys) enforceQuotaHard(ctx context.Context, bucket string, 
 		return err
 	}
 
-	var quotaSize uint64
-	if q != nil && q.Type == madmin.HardQuota {
-		if q.Size > 0 {
-			quotaSize = q.Size
-		} else if q.Quota > 0 {
-			quotaSize = q.Quota
-		}
-	}
+	quotaSize := getBucketQuotaSize(q)
 	if quotaSize > 0 {
 		if uint64(size) >= quotaSize { // check if file size already exceeds the quota
 			return BucketQuotaExceeded{Bucket: bucket}

--- a/cmd/bucket-quota_test.go
+++ b/cmd/bucket-quota_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-2025 MinIO, Inc.
+// Copyright (c) 2025-2026 PGSTY
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/minio/madmin-go/v3"
+)
+
+func TestGetBucketQuotaSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		quota *madmin.BucketQuota
+		want  uint64
+	}{
+		{name: "nil"},
+		{name: "empty", quota: &madmin.BucketQuota{}},
+		{name: "current size", quota: &madmin.BucketQuota{Type: madmin.HardQuota, Size: 1024}, want: 1024},
+		{name: "legacy quota", quota: &madmin.BucketQuota{Type: madmin.HardQuota, Quota: 2048}, want: 2048},
+		{name: "size takes precedence", quota: &madmin.BucketQuota{Type: madmin.HardQuota, Size: 1024, Quota: 2048}, want: 1024},
+		{name: "missing type", quota: &madmin.BucketQuota{Size: 1024}},
+		{name: "unsupported type", quota: &madmin.BucketQuota{Type: "fifo", Size: 1024}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getBucketQuotaSize(tt.quota); got != tt.want {
+				t.Fatalf("getBucketQuotaSize() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBktQuotaCfgReplicated(t *testing.T) {
+	hardQuota := func(size, legacy uint64) *madmin.BucketQuota {
+		return &madmin.BucketQuota{Type: madmin.HardQuota, Size: size, Quota: legacy}
+	}
+
+	tests := []struct {
+		name   string
+		quotas []*madmin.BucketQuota
+		want   bool
+	}{
+		{name: "none configured", quotas: []*madmin.BucketQuota{nil, nil}, want: true},
+		{name: "missing from one site", quotas: []*madmin.BucketQuota{hardQuota(1024, 0), nil}},
+		{name: "matching size", quotas: []*madmin.BucketQuota{hardQuota(1024, 0), hardQuota(1024, 0)}, want: true},
+		{name: "different size", quotas: []*madmin.BucketQuota{hardQuota(1024, 0), hardQuota(2048, 0)}},
+		{name: "equivalent representations", quotas: []*madmin.BucketQuota{hardQuota(1024, 0), hardQuota(0, 1024)}, want: true},
+		{name: "different typeless size", quotas: []*madmin.BucketQuota{{Size: 1024}, {Size: 2048}}},
+		{name: "different type", quotas: []*madmin.BucketQuota{hardQuota(1024, 0), {Type: "fifo", Size: 1024}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBktQuotaCfgReplicated(len(tt.quotas), tt.quotas); got != tt.want {
+				t.Fatalf("isBktQuotaCfgReplicated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/metrics-v2.go
+++ b/cmd/metrics-v2.go
@@ -3314,10 +3314,10 @@ func getBucketUsageMetrics(opts MetricsGroupOpts) *MetricsGroupV2 {
 				VariableLabels: map[string]string{"bucket": bucket},
 			})
 
-			if quota != nil && quota.Quota > 0 {
+			if quotaSize := getBucketQuotaSize(quota); quotaSize > 0 {
 				metrics = append(metrics, MetricV2{
 					Description:    getBucketUsageQuotaTotalBytesMD(),
-					Value:          float64(quota.Quota),
+					Value:          float64(quotaSize),
 					VariableLabels: map[string]string{"bucket": bucket},
 				})
 			}

--- a/cmd/metrics-v3-cluster-usage.go
+++ b/cmd/metrics-v3-cluster-usage.go
@@ -167,8 +167,8 @@ func loadClusterUsageBucketMetrics(ctx context.Context, m MetricValues, c *metri
 		m.Set(usageBucketVersionsCount, float64(usage.VersionsCount), "bucket", bucket)
 		m.Set(usageBucketDeleteMarkersCount, float64(usage.DeleteMarkersCount), "bucket", bucket)
 
-		if quota != nil && quota.Quota > 0 {
-			m.Set(usageBucketQuotaTotalBytes, float64(quota.Quota), "bucket", bucket)
+		if quotaSize := getBucketQuotaSize(quota); quotaSize > 0 {
+			m.Set(usageBucketQuotaTotalBytes, float64(quotaSize), "bucket", bucket)
 		}
 
 		for k, v := range usage.ObjectSizesHistogram {

--- a/cmd/site-replication.go
+++ b/cmd/site-replication.go
@@ -3863,7 +3863,16 @@ func isBktQuotaCfgReplicated(total int, quotaCfgs []*madmin.BucketQuota) bool {
 			prev = q
 			continue
 		}
-		if prev.Quota != q.Quota || prev.Type != q.Type {
+		if prev.Type != q.Type {
+			return false
+		}
+		if prev.Type == madmin.HardQuota {
+			if getBucketQuotaSize(prev) != getBucketQuotaSize(q) {
+				return false
+			}
+			continue
+		}
+		if prev.Size != q.Size || prev.Quota != q.Quota {
 			return false
 		}
 	}

--- a/cmd/veeam-sos-api.go
+++ b/cmd/veeam-sos-api.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/minio/madmin-go/v3"
 	"github.com/minio/minio/internal/logger"
 )
 
@@ -177,14 +176,7 @@ func veeamSOSAPIGetObject(ctx context.Context, bucket, object string, rs *HTTPRa
 			Used: int64(binfo.Size),
 		}
 
-		var quotaSize int64
-		if q != nil && q.Type == madmin.HardQuota {
-			if q.Size > 0 {
-				quotaSize = int64(q.Size)
-			} else if q.Quota > 0 {
-				quotaSize = int64(q.Quota)
-			}
-		}
+		quotaSize := int64(getBucketQuotaSize(q))
 
 		if quotaSize == 0 {
 			info := objAPI.StorageInfo(ctx, true)


### PR DESCRIPTION
## Contribution Licensing (no CLA, inbound=outbound, DCO required)

This project does not use a CLA; contributions are accepted inbound=outbound.
By submitting this pull request I represent that I have the right to contribute
the changes, which are licensed under this repository's
[GNU Affero General Public License v3.0 or later](https://www.gnu.org/licenses/agpl-3.0.html)
and remain my copyright. Every commit carries a DCO `Signed-off-by` trailer
certifying the
[Developer Certificate of Origin](https://developercertificate.org/).

## Description

Report bucket quota metrics from the quota value the server actually enforces.
The shared quota-size selector prefers `BucketQuota.Size` and retains
`BucketQuota.Quota` as a fallback for legacy configurations.

Site-replication status now compares effective hard-quota values while still
detecting raw size drift in unsupported or typeless configurations.

## Motivation and Context

The v2 and v3 bucket usage collectors still read the deprecated `Quota` field.
Quotas stored in the current `Size` field therefore produced a missing or zero
quota metric even though the server enforced them.

Fixes #106.

## How to test this PR?

```sh
go test ./cmd -run '^Test(GetBucketQuotaSize|IsBktQuotaCfgReplicated|GetHistogramMetrics_BucketCount|GetHistogramMetrics_Values)$' -count=1
go vet ./cmd
make verifiers
make build
./silo --version
```

## Compatibility impact

There are no API, metric-name, label, route, storage-format, or configuration
schema changes. Current `Size` quotas are now reported correctly, legacy
`Quota` values remain supported, and non-hard quotas are not advertised as
enforced. Site-replication status now detects differing `Size` values while
treating equivalent current and legacy hard-quota representations as equal.

Rollback requires no data migration; it only restores the previous incorrect
metric and replication-status behavior. No compatibility identifiers change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] All commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] Fixes a regression (`5b114b43f7a657c6ab964cadd318505cba7f25c1` migrated quota enforcement to `Size` without updating metrics)
- [x] Unit tests added/updated
- [x] `make verifiers` passes
- [x] Relevant package tests and `make build` pass
- [x] Compatibility and rollback impact documented
- [x] Internal documentation updated (not required; no internal workflow changed)
- [x] Public documentation update opened in `pgsty/silo.pgsty.com`, if needed (not needed; the metric contract is unchanged)
