### PR TITLE
fix: count resync success by replication outcome, not target existence

### DIFF
--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -418,7 +418,12 @@ func checkReplicateDelete(ctx context.Context, bucket string, dobj ObjectToDelet
 // target cluster, the object version is marked deleted on the source and hidden from listing. It is permanently
 // deleted from the source when the VersionPurgeStatus changes to "Complete", i.e after replication succeeds
 // on target.
-func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, objectAPI ObjectLayer) {
+// replicateDelete replicates a delete (delete marker or version purge) to all
+// applicable targets and returns the per-target replication outcome. Callers
+// that only trigger replication may ignore the return value; the resync path
+// uses it to classify success/failure per target rather than inferring it from
+// the mere presence or absence of the target version.
+func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, objectAPI ObjectLayer) replicatedInfos {
 	var replicationStatus replication.StatusType
 	bucket := dobj.Bucket
 	versionID := dobj.DeleteMarkerVersionID
@@ -453,7 +458,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 			Host:      globalLocalNodeName,
 			EventName: event.ObjectReplicationNotTracked,
 		})
-		return
+		return replicatedInfos{}
 	}
 	dsc, err := parseReplicateDecision(ctx, bucket, dobj.ReplicationState.ReplicateDecisionStr)
 	if err != nil {
@@ -471,7 +476,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 			Host:      globalLocalNodeName,
 			EventName: event.ObjectReplicationNotTracked,
 		})
-		return
+		return replicatedInfos{}
 	}
 
 	// Lock the object name before starting replication operation.
@@ -492,7 +497,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 			Host:      globalLocalNodeName,
 			EventName: event.ObjectReplicationNotTracked,
 		})
-		return
+		return replicatedInfos{}
 	}
 	ctx = lkctx.Context()
 	defer lk.Unlock(lkctx)
@@ -597,6 +602,7 @@ func replicateDelete(ctx context.Context, dobj DeletedObjectReplicationInfo, obj
 			EventName:  eventName,
 		})
 	}
+	return rinfos
 }
 
 func replicateDeleteToTarget(ctx context.Context, dobj DeletedObjectReplicationInfo, tgt *TargetClient) (rinfo replicatedTargetInfo) {
@@ -1035,7 +1041,12 @@ func getReplicationAction(oi1 ObjectInfo, oi2 minio.ObjectInfo, opType replicati
 
 // replicateObject replicates the specified version of the object to destination bucket
 // The source object is then updated to reflect the replication status.
-func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI ObjectLayer) {
+// replicateObject replicates a single object version to all applicable targets
+// and returns the per-target replication outcome. Callers that only trigger
+// replication may ignore the return value; the resync path uses it to classify
+// success/failure per target rather than inferring it from the mere existence
+// of the target version.
+func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI ObjectLayer) replicatedInfos {
 	var replicationStatus replication.StatusType
 	defer func() {
 		if replicationStatus.Empty() {
@@ -1068,7 +1079,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 			UserAgent:  "Internal: [Replication]",
 			Host:       globalLocalNodeName,
 		})
-		return
+		return replicatedInfos{}
 	}
 	tgtArns := cfg.FilterTargetArns(replication.ObjectOpts{
 		Name:     object,
@@ -1088,7 +1099,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 			Host:       globalLocalNodeName,
 		})
 		globalReplicationPool.Get().queueMRFSave(ri.ToMRFEntry())
-		return
+		return replicatedInfos{}
 	}
 	ctx = lkctx.Context()
 	defer lk.Unlock(lkctx)
@@ -1194,6 +1205,7 @@ func replicateObject(ctx context.Context, ri ReplicateObjectInfo, objectAPI Obje
 		ri.RetryCount++
 		globalReplicationPool.Get().queueMRFSave(ri.ToMRFEntry())
 	}
+	return rinfos
 }
 
 // replicateObject replicates object data for specified version of the object to destination bucket
@@ -2968,6 +2980,55 @@ func finalResyncStatus(status ResyncStatusType, ctxErr error, workerAborted bool
 	return status
 }
 
+// resyncTargetSucceeded reports whether this object (or delete) actually
+// replicated to the target, from the target's own outcome. A version purge
+// reports success through VersionPurgeStatus, not ReplicationStatus. For an
+// object or delete marker, success requires a Completed status; a retained
+// error is a real failure unless it is the benign duplicate 412 the
+// destination returns when it already holds this exact ETag and version, which
+// replicateAll deliberately keeps Completed.
+func resyncTargetSucceeded(t replicatedTargetInfo, roi ReplicateObjectInfo) bool {
+	if !roi.VersionPurgeStatus.Empty() {
+		return t.VersionPurgeStatus == replication.VersionPurgeComplete
+	}
+	if t.ReplicationStatus != replication.Completed {
+		return false
+	}
+	return t.Err == nil || minio.ToErrorResponse(t.Err).Code == "PreconditionFailed"
+}
+
+// resyncResultFor derives the resync outcome for target arn from the aggregate
+// replication result of a single object (or delete). The target counts as a
+// success only when its own replication Completed without error - not when the
+// target version merely exists. A target that Failed, errored, or was not
+// attempted for this object (its arn absent from the result) counts as a
+// failure, and the failed byte count is recorded (previously always zero).
+func resyncResultFor(rinfos replicatedInfos, arn string, roi ReplicateObjectInfo) TargetReplicationResyncStatus {
+	st := TargetReplicationResyncStatus{Object: roi.Name, Bucket: roi.Bucket}
+	for _, t := range rinfos.Targets {
+		if t.Arn != arn {
+			continue
+		}
+		if resyncTargetSucceeded(t, roi) {
+			sz := t.Size
+			if sz == 0 {
+				sz = roi.Size
+			}
+			st.ReplicatedCount++
+			st.ReplicatedSize += sz
+		} else {
+			st.FailedCount++
+			st.FailedSize += roi.Size
+		}
+		return st
+	}
+	// arn was not attempted for this object: a resync that cannot confirm the
+	// object reached the target is not a success.
+	st.FailedCount++
+	st.FailedSize += roi.Size
+	return st
+}
+
 // resyncBucket resyncs all qualifying objects as per replication rules for the target
 // ARN
 func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI ObjectLayer, heal bool, opts resyncOpts) {
@@ -3067,6 +3128,7 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 				default:
 				}
 				traceFn := s.trace(tgt.ResetID, fmt.Sprintf("%s/%s (%s)", opts.bucket, roi.Name, roi.VersionID))
+				var rinfos replicatedInfos
 				if roi.DeleteMarker || !roi.VersionPurgeStatus.Empty() {
 					versionID := ""
 					dmVersionID := ""
@@ -3089,37 +3151,26 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 						OpType:    replication.ExistingObjectReplicationType,
 						EventType: ReplicateExistingDelete,
 					}
-					replicateDelete(ctx, doi, objectAPI)
+					rinfos = replicateDelete(ctx, doi, objectAPI)
 				} else {
 					roi.OpType = replication.ExistingObjectReplicationType
 					roi.EventType = ReplicateExisting
-					replicateObject(ctx, roi, objectAPI)
+					rinfos = replicateObject(ctx, roi, objectAPI)
 				}
 
-				st := TargetReplicationResyncStatus{
-					Object: roi.Name,
-					Bucket: roi.Bucket,
-				}
-
-				_, err := tgt.StatObject(ctx, tgt.Bucket, roi.Name, minio.StatObjectOptions{
-					VersionID: roi.VersionID,
-					Internal: minio.AdvancedGetOptions{
-						ReplicationProxyRequest: "false",
-					},
-				})
-				sz := roi.Size
-				if err != nil {
-					if roi.DeleteMarker && isErrMethodNotAllowed(ErrorRespToObjectError(err, opts.bucket, roi.Name)) {
-						st.ReplicatedCount++
-					} else {
-						st.FailedCount++
+				// Classify success/failure from the actual replication outcome
+				// for this target, not from whether the target version merely
+				// exists (a rejected update leaves the old version in place).
+				st := resyncResultFor(rinfos, opts.arn, roi)
+				var traceSize int64
+				var traceErr error
+				for i := range rinfos.Targets {
+					if rinfos.Targets[i].Arn == opts.arn {
+						traceSize, traceErr = rinfos.Targets[i].Size, rinfos.Targets[i].Err
+						break
 					}
-					sz = 0
-				} else {
-					st.ReplicatedCount++
-					st.ReplicatedSize += roi.Size
 				}
-				traceFn(sz, err)
+				traceFn(traceSize, traceErr)
 				if !s.sendResyncResult(ctx, results.ch, st, &workerAborted) {
 					return
 				}

--- a/cmd/bucket-replication.go
+++ b/cmd/bucket-replication.go
@@ -2886,6 +2886,88 @@ func (s *replicationResyncer) incStats(ts TargetReplicationResyncStatus, opts re
 	s.statusMap[opts.bucket] = m
 }
 
+// resyncResults consumes the per-object outcomes produced by the resync worker
+// pool and applies each to the in-memory resync status via apply. It centralizes
+// the finalization ordering so a status persisted after finish() returns always
+// reflects every result.
+type resyncResults struct {
+	ch    chan TargetReplicationResyncStatus
+	apply func(TargetReplicationResyncStatus)
+	wg    sync.WaitGroup
+}
+
+// newResyncResults starts the result-consuming goroutine that folds each worker
+// result into the bucket's resync status.
+func (s *replicationResyncer) newResyncResults(opts resyncOpts) *resyncResults {
+	return startResyncResults(func(r TargetReplicationResyncStatus) {
+		s.incStats(r, opts)
+		globalSiteResyncMetrics.updateMetric(r, opts.resyncID)
+	})
+}
+
+// startResyncResults starts a goroutine that applies every received result with
+// apply. Injecting the apply action keeps the shutdown ordering in finish()
+// testable.
+func startResyncResults(apply func(TargetReplicationResyncStatus)) *resyncResults {
+	rr := &resyncResults{
+		ch:    make(chan TargetReplicationResyncStatus, 1),
+		apply: apply,
+	}
+	rr.wg.Add(1)
+	go func() {
+		defer rr.wg.Done()
+		for r := range rr.ch {
+			rr.apply(r)
+		}
+	}()
+	return rr
+}
+
+// finish shuts the resync pipeline down in an order that guarantees a status
+// persisted afterwards reflects every result. It first closes the worker input
+// channels and waits for the producer workers to exit, so none can send on a
+// closed result channel (a hazard on early-return paths) and every submitted
+// result is delivered (a result a worker discards on cancellation is
+// intentionally not); only then does it close the result channel and wait for
+// the consumer to apply the last buffered result.
+func (rr *resyncResults) finish(workers []chan ReplicateObjectInfo, workerWg *sync.WaitGroup) {
+	for i := range workers {
+		xioutil.SafeClose(workers[i])
+	}
+	workerWg.Wait()
+	xioutil.SafeClose(rr.ch)
+	rr.wg.Wait()
+}
+
+// sendResyncResult delivers a worker's computed per-object result to ch,
+// returning false if the worker must stop first. On the resync-cancel signal it
+// records the abort - the already-computed result is dropped - so
+// finalResyncStatus can downgrade a Completed run; on ctx cancellation it stops
+// without recording, since finalResyncStatus's parent-context check covers that.
+func (s *replicationResyncer) sendResyncResult(ctx context.Context, ch chan<- TargetReplicationResyncStatus, st TargetReplicationResyncStatus, workerAborted *atomic.Bool) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-s.resyncCancelCh:
+		workerAborted.Store(true)
+		return false
+	case ch <- st:
+		return true
+	}
+}
+
+// finalResyncStatus downgrades a Completed status to Failed when the run could
+// not have observed every object: the parent context was canceled (workers then
+// return without sending their computed result) or a worker dropped a result on
+// the resync-cancel signal. Without this a persisted Completed would misrepresent
+// an incomplete resync.
+func finalResyncStatus(status ResyncStatusType, ctxErr error, workerAborted bool) ResyncStatusType {
+	if status == ResyncCompleted && (ctxErr != nil || workerAborted) {
+		return ResyncFailed
+	}
+	return status
+}
+
 // resyncBucket resyncs all qualifying objects as per replication rules for the target
 // ARN
 func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI ObjectLayer, heal bool, opts resyncOpts) {
@@ -2896,7 +2978,18 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 	}
 
 	resyncStatus := ResyncFailed
+	// workerAborted records that a worker dropped an already-computed result on
+	// the resync-cancel signal. With a canceled parent context (which makes
+	// workers return without sending their result), it means a Completed run did
+	// not actually observe every object - see finalResyncStatus below.
+	var workerAborted atomic.Bool
 	defer func() {
+		// Downgrade a Completed status whose counts are incomplete, so the
+		// persisted status is not a misleading Completed. Runs after results.finish
+		// drains (LIFO) and before markStatus persists - markStatus uses its own
+		// background context, so a parent cancellation during the drain would
+		// otherwise still record Completed.
+		resyncStatus = finalResyncStatus(resyncStatus, ctx.Err(), workerAborted.Load())
 		s.markStatus(resyncStatus, opts, objectAPI)
 		globalSiteResyncMetrics.incBucket(opts, resyncStatus)
 		s.workerCh <- struct{}{}
@@ -2952,16 +3045,14 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 		lastCheckpoint = st.Object
 	}
 	workers := make([]chan ReplicateObjectInfo, resyncParallelRoutines)
-	resultCh := make(chan TargetReplicationResyncStatus, 1)
-	defer xioutil.SafeClose(resultCh)
-	go func() {
-		for r := range resultCh {
-			s.incStats(r, opts)
-			globalSiteResyncMetrics.updateMetric(r, opts.resyncID)
-		}
-	}()
-
 	var wg sync.WaitGroup
+	// results consumes each worker's per-object outcome and folds it into the
+	// in-memory status. finish() (deferred below) stops the workers and drains
+	// every result before the deferred markStatus persists, so a Completed status
+	// cannot race the last incStats. Registered after the markStatus finalizer, so
+	// LIFO runs finish first.
+	results := s.newResyncResults(opts)
+	defer results.finish(workers, &wg)
 	for i := range resyncParallelRoutines {
 		wg.Add(1)
 		workers[i] = make(chan ReplicateObjectInfo, 100)
@@ -3029,12 +3120,8 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 					st.ReplicatedSize += roi.Size
 				}
 				traceFn(sz, err)
-				select {
-				case <-ctx.Done():
+				if !s.sendResyncResult(ctx, results.ch, st, &workerAborted) {
 					return
-				case <-s.resyncCancelCh:
-					return
-				case resultCh <- st:
 				}
 			}
 		}(ctx, i)
@@ -3071,10 +3158,6 @@ func (s *replicationResyncer) resyncBucket(ctx context.Context, objectAPI Object
 			workers[h%uint64(resyncParallelRoutines)] <- roi
 		}
 	}
-	for i := range resyncParallelRoutines {
-		xioutil.SafeClose(workers[i])
-	}
-	wg.Wait()
 	resyncStatus = ResyncCompleted
 }
 

--- a/cmd/bucket-replication_test.go
+++ b/cmd/bucket-replication_test.go
@@ -18,10 +18,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/minio/madmin-go/v3"
@@ -306,4 +310,221 @@ func TestReplicationValidationObjectUsesRulePrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The resync-finalization tests below exercise the real result sink, the
+// finish() shutdown ordering, and the sendResyncResult / finalResyncStatus
+// helpers, plus (for the persistence cases) markStatus with on-disk
+// round-tripping. resyncBucket cannot be driven end to end in a unit test
+// because its workers call a live remote target (StatObject), so the helpers it
+// uses are exercised directly. The blocking-order assertions run under
+// testing/synctest so a removed wait fails deterministically, with no timing
+// windows.
+
+func newTestResyncer(bucket, arn string) (*replicationResyncer, resyncOpts) {
+	s := &replicationResyncer{
+		statusMap:      map[string]BucketReplicationResyncStatus{},
+		resyncCancelCh: make(chan struct{}, resyncWorkerCnt),
+	}
+	brs := newBucketResyncStatus(bucket)
+	brs.TargetsMap[arn] = TargetReplicationResyncStatus{ResyncStatus: ResyncStarted}
+	s.statusMap[bucket] = brs
+	return s, resyncOpts{bucket: bucket, arn: arn, resyncID: "reset-" + bucket}
+}
+
+// TestResyncBucketFinalize round-trips the terminal status through a real
+// ObjectLayer: a clean run persists Completed with every result, while a run
+// whose parent context was canceled during the drain, or in which a worker
+// dropped a result on the cancel signal, is downgraded to Failed so a persisted
+// Completed never misrepresents an incomplete resync.
+func TestResyncBucketFinalize(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	objAPI, fsDirs, err := prepareErasure16(ctx)
+	if err != nil {
+		t.Fatalf("prepare erasure backend: %v", err)
+	}
+	defer removeRoots(fsDirs)
+
+	// persistTerminal applies resyncBucket's finalizer logic (finalResyncStatus
+	// then markStatus, which persists) and reads the status back the way the
+	// resync status API does.
+	persistTerminal := func(t *testing.T, s *replicationResyncer, opts resyncOpts, status ResyncStatusType, ctxErr error, aborted bool) TargetReplicationResyncStatus {
+		t.Helper()
+		s.markStatus(finalResyncStatus(status, ctxErr, aborted), opts, objAPI)
+		brs, err := loadBucketResyncMetadata(ctx, opts.bucket, objAPI)
+		if err != nil {
+			t.Fatalf("load persisted resync metadata: %v", err)
+		}
+		return brs.TargetsMap[opts.arn]
+	}
+
+	// 1. Clean completion: every result - including the failed object - is folded
+	//    into the persisted status, which stays Completed.
+	t.Run("persists complete counts", func(t *testing.T) {
+		s, opts := newTestResyncer("finalize-counts", "arn1")
+		results := s.newResyncResults(opts)
+		results.ch <- TargetReplicationResyncStatus{Object: "ok-1", ReplicatedCount: 1, ReplicatedSize: 100}
+		results.ch <- TargetReplicationResyncStatus{Object: "ok-2", ReplicatedCount: 1, ReplicatedSize: 200}
+		results.ch <- TargetReplicationResyncStatus{Object: "bad", FailedCount: 1, FailedSize: 300}
+
+		var wg sync.WaitGroup // no producer workers for this case
+		results.finish(nil, &wg)
+
+		st := persistTerminal(t, s, opts, ResyncCompleted, nil, false)
+		if st.ResyncStatus != ResyncCompleted {
+			t.Fatalf("persisted status = %s, want Completed", st.ResyncStatus)
+		}
+		if st.ReplicatedCount != 2 || st.ReplicatedSize != 300 || st.FailedCount != 1 || st.FailedSize != 300 {
+			t.Fatalf("persisted counts = {replicated:%d/%d failed:%d/%d}, want {2/300 1/300}",
+				st.ReplicatedCount, st.ReplicatedSize, st.FailedCount, st.FailedSize)
+		}
+	})
+
+	// 2. Parent context canceled during the drain -> Completed downgraded to
+	//    Failed (markStatus persists under its own context, so nothing else stops
+	//    a bare Completed from being recorded).
+	t.Run("parent cancel during drain downgrades to failed", func(t *testing.T) {
+		s, opts := newTestResyncer("finalize-parent-cancel", "arn1")
+		results := s.newResyncResults(opts)
+		results.ch <- TargetReplicationResyncStatus{Object: "ok-1", ReplicatedCount: 1, ReplicatedSize: 100}
+		var wg sync.WaitGroup
+		results.finish(nil, &wg)
+
+		cctx, ccancel := context.WithCancel(context.Background())
+		ccancel()
+		st := persistTerminal(t, s, opts, ResyncCompleted, cctx.Err(), false)
+		if st.ResyncStatus != ResyncFailed {
+			t.Fatalf("persisted status = %s, want Failed (parent canceled during drain)", st.ResyncStatus)
+		}
+	})
+
+	// 3. A worker dropped a computed result on the resync-cancel token (parent
+	//    still alive) -> sendResyncResult records the abort and Completed is
+	//    downgraded to Failed.
+	t.Run("worker abort downgrades to failed", func(t *testing.T) {
+		s, opts := newTestResyncer("finalize-worker-abort", "arn1")
+		s.resyncCancelCh <- struct{}{}                 // cancel token waiting
+		ch := make(chan TargetReplicationResyncStatus) // no reader: the send would block
+		var aborted atomic.Bool
+		if s.sendResyncResult(context.Background(), ch, TargetReplicationResyncStatus{Object: "dropped", ReplicatedCount: 1}, &aborted) {
+			t.Fatal("sendResyncResult reported success despite the cancel token")
+		}
+		if !aborted.Load() {
+			t.Fatal("worker abort was not recorded")
+		}
+		st := persistTerminal(t, s, opts, ResyncCompleted, nil, aborted.Load())
+		if st.ResyncStatus != ResyncFailed {
+			t.Fatalf("persisted status = %s, want Failed (worker dropped a result)", st.ResyncStatus)
+		}
+	})
+}
+
+// TestResyncFinishDrainsResults asserts finish() does not return until the
+// consumer has applied the final result (the #136 defect). A gated apply holds
+// the last result unapplied; under synctest finish() must stay durably blocked
+// until it is released - if rr.wg.Wait() is removed, finish() returns early and
+// the test fails deterministically.
+func TestResyncFinishDrainsResults(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, opts := newTestResyncer("drain", "arn1")
+		reachedFinal := make(chan struct{})
+		release := make(chan struct{})
+		results := startResyncResults(func(r TargetReplicationResyncStatus) {
+			if r.Object == "final" {
+				close(reachedFinal)
+				<-release
+			}
+			s.incStats(r, opts)
+		})
+		results.ch <- TargetReplicationResyncStatus{Object: "ok-1", ReplicatedCount: 1, ReplicatedSize: 100}
+		results.ch <- TargetReplicationResyncStatus{Object: "final", FailedCount: 1, FailedSize: 200}
+		<-reachedFinal // consumer received "final" but is gated before incStats(final)
+
+		var wg sync.WaitGroup
+		finishDone := make(chan struct{})
+		go func() {
+			results.finish(nil, &wg)
+			close(finishDone)
+		}()
+
+		synctest.Wait()
+		select {
+		case <-finishDone:
+			close(release)
+			synctest.Wait()
+			t.Fatal("finish() returned before the final result was drained (drain wait missing)")
+		default:
+			// finish() is durably blocked in rr.wg.Wait() - correct.
+		}
+
+		close(release)
+		synctest.Wait()
+		<-finishDone
+		st := s.statusMap[opts.bucket].TargetsMap[opts.arn]
+		if st.ReplicatedCount != 1 || st.FailedCount != 1 || st.FailedSize != 200 {
+			t.Fatalf("status after finish = {replicated:%d failed:%d/%d}, want {1 1/200}",
+				st.ReplicatedCount, st.FailedCount, st.FailedSize)
+		}
+	})
+}
+
+// TestResyncFinishWaitsForInflightWorker asserts finish() stops the producer
+// workers before it closes the result channel, so an in-flight worker (as on an
+// early-return path) never sends on a closed channel and its result is not lost.
+// A gated worker stays in flight past the shutdown request; under synctest
+// finish() must stay durably blocked until the worker is released - if
+// workerWg.Wait() is removed, finish() returns early and the test fails
+// deterministically.
+func TestResyncFinishWaitsForInflightWorker(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		s, opts := newTestResyncer("workers", "arn1")
+		results := startResyncResults(func(r TargetReplicationResyncStatus) { s.incStats(r, opts) })
+
+		workers := []chan ReplicateObjectInfo{make(chan ReplicateObjectInfo, 1)}
+		var wg sync.WaitGroup
+		gotRoi := make(chan struct{})
+		release := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for roi := range workers[0] {
+				close(gotRoi)
+				<-release
+				// Mirror the real worker's send; recover so that if finish()
+				// wrongly closed the result channel first, the test fails via the
+				// assertion below instead of crashing on send-on-closed.
+				func() {
+					defer func() { _ = recover() }()
+					results.ch <- TargetReplicationResyncStatus{Object: roi.Name, ReplicatedCount: 1, ReplicatedSize: 500}
+				}()
+			}
+		}()
+		workers[0] <- ReplicateObjectInfo{Name: "inflight"}
+		<-gotRoi // worker holds a result in flight, not yet delivered
+
+		finishDone := make(chan struct{})
+		go func() {
+			results.finish(workers, &wg)
+			close(finishDone)
+		}()
+
+		synctest.Wait()
+		select {
+		case <-finishDone:
+			close(release)
+			synctest.Wait()
+			t.Fatal("finish() closed the result channel before the in-flight worker finished (worker wait missing)")
+		default:
+			// finish() is durably blocked in workerWg.Wait() - correct.
+		}
+
+		close(release)
+		synctest.Wait()
+		<-finishDone
+		st := s.statusMap[opts.bucket].TargetsMap[opts.arn]
+		if st.ReplicatedCount != 1 || st.ReplicatedSize != 500 {
+			t.Fatalf("status after finish = {replicated:%d/%d}, want {1/500}", st.ReplicatedCount, st.ReplicatedSize)
+		}
+	})
 }

--- a/cmd/bucket-replication_test.go
+++ b/cmd/bucket-replication_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/minio/madmin-go/v3"
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio/internal/bucket/replication"
 	xhttp "github.com/minio/minio/internal/http"
 )
@@ -527,4 +528,122 @@ func TestResyncFinishWaitsForInflightWorker(t *testing.T) {
 			t.Fatalf("status after finish = {replicated:%d/%d}, want {1/500}", st.ReplicatedCount, st.ReplicatedSize)
 		}
 	})
+}
+
+// TestResyncResultFor asserts the resync worker classifies a target from the
+// actual replication outcome, not from whether the target version merely exists.
+// The key regression is the "failed update over an existing version" case: a
+// quota-rejected update leaves the old version in place, and counting existence
+// (the previous behavior) would score it a success. It also checks a genuine
+// success, an errored-but-Completed result, a delete failure, a delete-marker
+// success (zero bytes), and an ARN that was never attempted.
+func TestResyncResultFor(t *testing.T) {
+	const arn = "arn:minio:replication::id:bucket"
+	obj := ReplicateObjectInfo{Name: "obj", Bucket: "bucket", Size: 196608}
+	deleteMarker := ReplicateObjectInfo{Name: "dm", Bucket: "bucket", Size: 0, DeleteMarker: true}
+
+	tests := []struct {
+		name                                           string
+		roi                                            ReplicateObjectInfo
+		rinfos                                         replicatedInfos
+		wantRepl, wantReplSize, wantFail, wantFailSize int64
+	}{
+		{
+			name: "completed update",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Completed, Size: 196608},
+			}},
+			wantRepl: 1, wantReplSize: 196608,
+		},
+		{
+			name: "failed update over existing version",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Failed, Err: fmt.Errorf("quota exceeded"), Size: 196608},
+			}},
+			wantFail: 1, wantFailSize: 196608,
+		},
+		{
+			name: "completed but errored is a failure",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Completed, Err: fmt.Errorf("boom"), Size: 196608},
+			}},
+			wantFail: 1, wantFailSize: 196608,
+		},
+		{
+			name: "delete failed",
+			roi:  deleteMarker,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Failed},
+			}},
+			wantFail: 1, wantFailSize: 0,
+		},
+		{
+			name: "delete marker replicated counts zero bytes",
+			roi:  deleteMarker,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Completed},
+			}},
+			wantRepl: 1, wantReplSize: 0,
+		},
+		{
+			name: "arn not attempted is a failure",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: "arn:minio:replication::id2:bucket", ReplicationStatus: replication.Completed, Size: 196608},
+			}},
+			wantFail: 1, wantFailSize: 196608,
+		},
+		{
+			name: "completed with zero size falls back to object size",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, ReplicationStatus: replication.Completed, Size: 0},
+			}},
+			wantRepl: 1, wantReplSize: 196608,
+		},
+		{
+			name: "version purge complete is a success",
+			roi:  ReplicateObjectInfo{Name: "purge", Bucket: "bucket", Size: 196608, VersionPurgeStatus: replication.VersionPurgePending},
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				// a successful purge sets only VersionPurgeStatus; ReplicationStatus stays empty.
+				{Arn: arn, VersionPurgeStatus: replication.VersionPurgeComplete},
+			}},
+			wantRepl: 1, wantReplSize: 196608,
+		},
+		{
+			name: "version purge failed is a failure",
+			roi:  ReplicateObjectInfo{Name: "purge", Bucket: "bucket", Size: 196608, VersionPurgeStatus: replication.VersionPurgePending},
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				{Arn: arn, VersionPurgeStatus: replication.VersionPurgeFailed, Err: fmt.Errorf("quota exceeded")},
+			}},
+			wantFail: 1, wantFailSize: 196608,
+		},
+		{
+			name: "benign duplicate 412 is a success",
+			roi:  obj,
+			rinfos: replicatedInfos{Targets: []replicatedTargetInfo{
+				// the destination answers PreconditionFailed for an exact duplicate;
+				// replicateAll keeps Completed but retains the error.
+				{Arn: arn, ReplicationStatus: replication.Completed, Err: minio.ErrorResponse{Code: "PreconditionFailed"}, Size: 196608},
+			}},
+			wantRepl: 1, wantReplSize: 196608,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := resyncResultFor(tc.rinfos, arn, tc.roi)
+			if st.Object != tc.roi.Name || st.Bucket != tc.roi.Bucket {
+				t.Fatalf("object/bucket = %s/%s, want %s/%s", st.Object, st.Bucket, tc.roi.Name, tc.roi.Bucket)
+			}
+			if st.ReplicatedCount != tc.wantRepl || st.ReplicatedSize != tc.wantReplSize ||
+				st.FailedCount != tc.wantFail || st.FailedSize != tc.wantFailSize {
+				t.Fatalf("resyncResultFor = {replicated:%d/%d failed:%d/%d}, want {%d/%d %d/%d}",
+					st.ReplicatedCount, st.ReplicatedSize, st.FailedCount, st.FailedSize,
+					tc.wantRepl, tc.wantReplSize, tc.wantFail, tc.wantFailSize)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

Fixes #139. **Stacked on #138** (`fix/issue-136-resync-counter-flush`) — review/merge #138 first; this PR's base retargets to `main` once #138 lands.

`resyncBucket`'s worker classified a per-object resync as success whenever the target **version merely existed** (`tgt.StatObject`), ignoring the outcome of the `replicateObject`/`replicateDelete` it had just run. A quota-rejected update leaves the old version in place, so it was falsely recorded `Completed` / success (persisted across restart). #134's SSE-C internal HEAD marker made `StatObject` succeed for SSE-C objects too, exposing the same defect there; the delete path had the mirror flaw; and `FailedSize` was never incremented.

## Fix (`cmd/bucket-replication.go`)

- `replicateObject` and `replicateDelete` now **return** the per-target `replicatedInfos` they already build (early returns → `replicatedInfos{}`; the metadata-persistence side effects are unchanged). The non-resync callers are call statements that discard the value.
- The resync worker classifies via pure helpers `resyncResultFor` / `resyncTargetSucceeded`, using the **`opts.arn` target's own outcome**:
  - object/delete-marker: success requires `ReplicationStatus == Completed`, tolerating only the benign duplicate `PreconditionFailed` (412) the destination returns for an exact ETag+version match;
  - version purge: success requires `VersionPurgeStatus == VersionPurgeComplete` (a purge leaves `ReplicationStatus` empty);
  - a failed/errored result, or `opts.arn` absent from the result, counts as a failure, and `FailedSize` is now recorded.
- The `StatObject`-existence block (and its delete-marker/`MethodNotAllowed` heuristic, now subsumed) is removed. **#134's SSE-C HEAD marker in `replicateAll` is untouched.**

## Scope / follow-ups

Counter *timing* is #138; cancellation robustness is #137; multi-pool is #133. Two items are deliberately out of scope: the compressed/encrypted byte-size approximation (pre-existing), and cross-ARN dispatch scoping (any-target `mustResync` can route a non-`opts.arn` object to a worker → conservatively counted a failure) — tracked as a follow-up.

## Adversarial review

Codex Astra 6 (Max), 2 rounds → **VERDICT PASS**. Round 1 caught two over-strict misclassifications (successful version purge; benign 412); round 2 confirmed both fixes correct and that all other result shapes (Replica/pending/empty/arbitrary `Completed+Err`, quota rejection) classify correctly.

## How to test

```
GOWORK=off go test -tags kqueue,dev ./cmd -count=1 -run '^TestResyncResultFor$'
```

Table-driven, 10 cases incl. the key regressions (failed update over an existing version → 1 failed / 196608 bytes / 0 replicated; version-purge complete/failed; benign 412). Red-on-revert confirmed for the existence heuristic and for both round-2 branches. `gofmt`/`go vet`/`go build`/`-race` clean; full `-run 'Resync' -count=1` passes (incl. #138's finalize tests on the stack).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Commits signed off (`git commit -s`)
- [x] `gofmt`/`go vet`/`go build`/`-race` clean; Resync tests pass
- [x] Adversarial Codex review PASS (2 rounds)
- [x] Follow-ups tracked (dispatch scoping); no wire/API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7qJqWwy8oFA6aCXWRzXQe