### PR TITLE
fix: restore embedded Console proxy and WebSocket configuration

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -257,10 +257,30 @@ func buildOpenIDConsoleConfig() consoleoauth2.OpenIDPCfg {
 	return m
 }
 
-func initConsoleServer() (*consoleapi.Server, error) {
-	// unset all console_ environment variables.
+// resetConsoleEnvironment preserves the embedded Console's supported resource
+// settings verbatim. Server derives all other Console settings itself.
+func resetConsoleEnvironment() {
 	for _, cenv := range env.List(consolePrefix) {
+		switch cenv {
+		case consoleapi.ConsoleWSMaxConnections,
+			consoleapi.ConsoleWSMaxConnectionsPerClient,
+			consoleapi.ConsoleWSMaxAnonymousConnections,
+			consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient:
+			continue
+		}
 		os.Unsetenv(cenv)
+	}
+}
+
+func initConsoleServer() (*consoleapi.Server, error) {
+	resetConsoleEnvironment()
+	// Validate explicitly: ConfigureAPI logs errors, but embedded Console logs
+	// are normally silenced. Return configuration failures to Server startup.
+	if err := consoleapi.ConfigureEmbeddedSourceIPTrust(); err != nil {
+		return nil, err
+	}
+	if err := consoleapi.ConfigureWebSocketLimits(); err != nil {
+		return nil, err
 	}
 
 	// enable all console environment variables

--- a/cmd/common-main_test.go
+++ b/cmd/common-main_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	consoleapi "github.com/minio/console/api"
 	"github.com/minio/minio/internal/config"
 )
 
@@ -421,6 +422,88 @@ func TestConsoleMinIOServerEnv(t *testing.T) {
 			}
 			if skipVerify != tt.wantSkipVerify {
 				t.Fatalf("skipVerify = %v, want %v", skipVerify, tt.wantSkipVerify)
+			}
+		})
+	}
+}
+
+// The startup path clears process environment, so preserve all existing Console
+// variables, including ones unrelated to this test, before exercising it.
+func preserveConsoleEnvironment(t *testing.T) {
+	t.Helper()
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, consolePrefix) {
+			name, value, _ := strings.Cut(entry, "=")
+			t.Setenv(name, value)
+		}
+	}
+}
+
+func TestResetConsoleEnvironment(t *testing.T) {
+	preserveConsoleEnvironment(t)
+	settings := map[string]string{
+		consoleapi.ConsoleWSMaxConnections:                   "2048",
+		consoleapi.ConsoleWSMaxConnectionsPerClient:          "512",
+		consoleapi.ConsoleWSMaxAnonymousConnections:          "128",
+		consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient: "16",
+	}
+	for key, value := range settings {
+		t.Setenv(key, value)
+	}
+	decoys := []string{"CONSOLE_MINIO_SERVER_TLS_SKIP_VERIFY", "CONSOLE_MINIO_SERVER", "CONSOLE_PBKDF_SALT", "CONSOLE_TRUSTED_PROXIES", "CONSOLE_WS_MAX_UNKNOWN"}
+	for _, key := range decoys {
+		t.Setenv(key, "operator-value")
+	}
+	resetConsoleEnvironment()
+	for key, want := range settings {
+		if got, present := os.LookupEnv(key); !present || got != want {
+			t.Errorf("%s = %q, present = %v; want %q", key, got, present, want)
+		}
+	}
+	for _, key := range decoys {
+		if _, present := os.LookupEnv(key); present {
+			t.Errorf("unsupported override %s survived", key)
+		}
+	}
+	for _, raw := range []string{"", " 16 ", "env://missing-limit"} {
+		t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient, raw)
+		resetConsoleEnvironment()
+		if got, present := os.LookupEnv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient); !present || got != raw {
+			t.Fatalf("raw value %q was changed to %q (present = %v)", raw, got, present)
+		}
+	}
+	os.Unsetenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient)
+	resetConsoleEnvironment()
+	if _, present := os.LookupEnv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient); present {
+		t.Fatal("unset setting became present")
+	}
+}
+
+func TestInitConsoleServerConfigurationErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name, proxy, limit, want string
+	}{
+		{"proxy error precedes limit error", "proxy.internal", "bad", "MINIO_API_TRUSTED_PROXIES"},
+		{"blank limit", "", "", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"non-integer limit", "", "bad", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"out-of-range limit", "", "0", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"inconsistent limits", "", "256", "must be less than"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Restore the process-wide library configuration after environment cleanup.
+			t.Cleanup(func() {
+				_ = consoleapi.ConfigureEmbeddedSourceIPTrust()
+				_ = consoleapi.ConfigureWebSocketLimits()
+			})
+			preserveConsoleEnvironment(t)
+			t.Setenv(consoleapi.EnvMinIOTrustedProxies, tt.proxy)
+			t.Setenv(consoleapi.ConsoleWSMaxConnections, "1024")
+			t.Setenv(consoleapi.ConsoleWSMaxConnectionsPerClient, "256")
+			t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnections, "64")
+			t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient, tt.limit)
+			server, err := initConsoleServer()
+			if err == nil || !strings.Contains(err.Error(), tt.want) || server != nil {
+				t.Fatalf("initConsoleServer() = %v, %v; want nil server and %q error", server, err, tt.want)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 // Console and MC retain their historical module paths for best-effort upstream
 // compatibility. Pin the maintained PGSTY implementations used by SILO.
-replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada
+replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a
 
 replace github.com/minio/mc => github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 // Console and MC retain their historical module paths for best-effort upstream
 // compatibility. Pin the maintained PGSTY implementations used by SILO.
-replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a
+replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260908011343-b39a84ada5e8
 
 replace github.com/minio/mc => github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9
 

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwp
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9 h1:kJkqK0hJrmvdTOPiI98HoPmET0SHYI9+ytaTRzQdGAs=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9/go.mod h1:+j12ENu7ggWIaBY4nakGABVmkjfJgogzijHIbaJFSOk=
-github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a h1:cjrffMJfZlwvDOM+0qk+QwuV6MY/I5+d8ztZ4UWVzrM=
-github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
+github.com/pgsty/silo-console v0.0.0-20260908011343-b39a84ada5e8 h1:B270uCa2FLThDqTIJ+TzKksOWAfjmik5mcugwZFVn4s=
+github.com/pgsty/silo-console v0.0.0-20260908011343-b39a84ada5e8/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
 github.com/pgsty/silo-pkg/v3 v3.13.2 h1:Clw11c/J54Tx6pijNCWtXiC7e0fwP/f5Tgeb6fsXg2w=
 github.com/pgsty/silo-pkg/v3 v3.13.2/go.mod h1:0GmaDA0ArQ8bkAI/obiSNTBQzdgBu6W0e0olDCbyXXo=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwp
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9 h1:kJkqK0hJrmvdTOPiI98HoPmET0SHYI9+ytaTRzQdGAs=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9/go.mod h1:+j12ENu7ggWIaBY4nakGABVmkjfJgogzijHIbaJFSOk=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada h1:vJkxm7GTLL0AvIGIt+JxMfhjMO5+msmj4rLeFueTaG8=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
+github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a h1:cjrffMJfZlwvDOM+0qk+QwuV6MY/I5+d8ztZ4UWVzrM=
+github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
 github.com/pgsty/silo-pkg/v3 v3.13.2 h1:Clw11c/J54Tx6pijNCWtXiC7e0fwP/f5Tgeb6fsXg2w=
 github.com/pgsty/silo-pkg/v3 v3.13.2/go.mod h1:0GmaDA0ArQ8bkAI/obiSNTBQzdgBu6W0e0olDCbyXXo=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=


### PR DESCRIPTION
The 0903 upgrade stopped recognizing client addresses forwarded by local proxies and discarded operators' WebSocket limits before configuring embedded Console. This changed SourceIp Allow/Deny decisions and kept anonymous public browsing capped at eight connections per address despite documented overrides.

Enable Console's embedded-only loopback TCP-peer policy and preserve exactly the four existing WebSocket limit variables, including their raw values and set/unset state. Validate both policies explicitly, in proxy-first order, and propagate errors through Server startup. Defaults, explicit `none`/`off`, forwarding-chain trust, standalone behavior and the #108 TLS repair stay intact.

Pin Console to the merged, validated mainline commit `b39a84ada5e8`, with verified module checksums. This includes the proxy initializer from pgsty/silo-console#46 and the accepted dependency/session/object-browser fixes consolidated in pgsty/silo-console#47. Console's full 35-job matrix and 3-job vulnerability workflow passed on that candidate, including the previously failing frontend dependency audit. Bilingual deployment/migration guidance is in pgsty/silo.pgsty.com#14.

Validation:
- Focused Server initialization/error/TLS tests and Console source-IP, Origin, WebSocket reservation/release and public-listing tests passed; Console tests also passed with `-race`.
- Actual Linux arm64 embedded Server: local-proxy Allow 200 / Deny 403; explicit lists omitting loopback work; `none`/`off` and forged non-loopback direct headers stay denied.
- Defaults accept eight anonymous sockets and reject the next two; all four raised settings, both directly and through `MINIO_CONFIG_ENV_FILE`, allow ten sockets with a real public-bucket listing. Standalone Console's raised limit works too.
- Invalid blank, numeric, range, relationship and literal `env://` settings exit with an actionable error. A focused call-site test separately verifies propagation of Console's own proxy initializer error before WebSocket validation.
- Server lint, `go vet ./...`, generated-file/credits checks and rebrand/entrypoint checks passed on the original fix; CI reruns these gates after the Console pin update.
- DNS-only certificate fixture: embedded loopback TLS root/user login 204; incorrect password 401.

No local dependency replacement, release, or deployment is included.

Closes #147.
Closes #148.
