### PR TITLE
fix: integrate accepted Console pagination and embedded configuration

### DIFF
--- a/cmd/common-main.go
+++ b/cmd/common-main.go
@@ -257,10 +257,30 @@ func buildOpenIDConsoleConfig() consoleoauth2.OpenIDPCfg {
 	return m
 }
 
-func initConsoleServer() (*consoleapi.Server, error) {
-	// unset all console_ environment variables.
+// resetConsoleEnvironment preserves the embedded Console's supported resource
+// settings verbatim. Server derives all other Console settings itself.
+func resetConsoleEnvironment() {
 	for _, cenv := range env.List(consolePrefix) {
+		switch cenv {
+		case consoleapi.ConsoleWSMaxConnections,
+			consoleapi.ConsoleWSMaxConnectionsPerClient,
+			consoleapi.ConsoleWSMaxAnonymousConnections,
+			consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient:
+			continue
+		}
 		os.Unsetenv(cenv)
+	}
+}
+
+func initConsoleServer() (*consoleapi.Server, error) {
+	resetConsoleEnvironment()
+	// Validate explicitly: ConfigureAPI logs errors, but embedded Console logs
+	// are normally silenced. Return configuration failures to Server startup.
+	if err := consoleapi.ConfigureEmbeddedSourceIPTrust(); err != nil {
+		return nil, err
+	}
+	if err := consoleapi.ConfigureWebSocketLimits(); err != nil {
+		return nil, err
 	}
 
 	// enable all console environment variables

--- a/cmd/common-main_test.go
+++ b/cmd/common-main_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	consoleapi "github.com/minio/console/api"
 	"github.com/minio/minio/internal/config"
 )
 
@@ -421,6 +422,88 @@ func TestConsoleMinIOServerEnv(t *testing.T) {
 			}
 			if skipVerify != tt.wantSkipVerify {
 				t.Fatalf("skipVerify = %v, want %v", skipVerify, tt.wantSkipVerify)
+			}
+		})
+	}
+}
+
+// The startup path clears process environment, so preserve all existing Console
+// variables, including ones unrelated to this test, before exercising it.
+func preserveConsoleEnvironment(t *testing.T) {
+	t.Helper()
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, consolePrefix) {
+			name, value, _ := strings.Cut(entry, "=")
+			t.Setenv(name, value)
+		}
+	}
+}
+
+func TestResetConsoleEnvironment(t *testing.T) {
+	preserveConsoleEnvironment(t)
+	settings := map[string]string{
+		consoleapi.ConsoleWSMaxConnections:                   "2048",
+		consoleapi.ConsoleWSMaxConnectionsPerClient:          "512",
+		consoleapi.ConsoleWSMaxAnonymousConnections:          "128",
+		consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient: "16",
+	}
+	for key, value := range settings {
+		t.Setenv(key, value)
+	}
+	decoys := []string{"CONSOLE_MINIO_SERVER_TLS_SKIP_VERIFY", "CONSOLE_MINIO_SERVER", "CONSOLE_PBKDF_SALT", "CONSOLE_TRUSTED_PROXIES", "CONSOLE_WS_MAX_UNKNOWN"}
+	for _, key := range decoys {
+		t.Setenv(key, "operator-value")
+	}
+	resetConsoleEnvironment()
+	for key, want := range settings {
+		if got, present := os.LookupEnv(key); !present || got != want {
+			t.Errorf("%s = %q, present = %v; want %q", key, got, present, want)
+		}
+	}
+	for _, key := range decoys {
+		if _, present := os.LookupEnv(key); present {
+			t.Errorf("unsupported override %s survived", key)
+		}
+	}
+	for _, raw := range []string{"", " 16 ", "env://missing-limit"} {
+		t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient, raw)
+		resetConsoleEnvironment()
+		if got, present := os.LookupEnv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient); !present || got != raw {
+			t.Fatalf("raw value %q was changed to %q (present = %v)", raw, got, present)
+		}
+	}
+	os.Unsetenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient)
+	resetConsoleEnvironment()
+	if _, present := os.LookupEnv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient); present {
+		t.Fatal("unset setting became present")
+	}
+}
+
+func TestInitConsoleServerConfigurationErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name, proxy, limit, want string
+	}{
+		{"proxy error precedes limit error", "proxy.internal", "bad", "MINIO_API_TRUSTED_PROXIES"},
+		{"blank limit", "", "", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"non-integer limit", "", "bad", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"out-of-range limit", "", "0", "CONSOLE_WS_MAX_ANONYMOUS_CONNECTIONS_PER_CLIENT"},
+		{"inconsistent limits", "", "256", "must be less than"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// Restore the process-wide library configuration after environment cleanup.
+			t.Cleanup(func() {
+				_ = consoleapi.ConfigureEmbeddedSourceIPTrust()
+				_ = consoleapi.ConfigureWebSocketLimits()
+			})
+			preserveConsoleEnvironment(t)
+			t.Setenv(consoleapi.EnvMinIOTrustedProxies, tt.proxy)
+			t.Setenv(consoleapi.ConsoleWSMaxConnections, "1024")
+			t.Setenv(consoleapi.ConsoleWSMaxConnectionsPerClient, "256")
+			t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnections, "64")
+			t.Setenv(consoleapi.ConsoleWSMaxAnonymousConnectionsPerClient, tt.limit)
+			server, err := initConsoleServer()
+			if err == nil || !strings.Contains(err.Error(), tt.want) || server != nil {
+				t.Fatalf("initConsoleServer() = %v, %v; want nil server and %q error", server, err, tt.want)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 // Console and MC retain their historical module paths for best-effort upstream
 // compatibility. Pin the maintained PGSTY implementations used by SILO.
-replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada
+replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a
 
 replace github.com/minio/mc => github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 // Console and MC retain their historical module paths for best-effort upstream
 // compatibility. Pin the maintained PGSTY implementations used by SILO.
-replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada
+replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e
 
 replace github.com/minio/mc => github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.27.1
 
 // Console and MC retain their historical module paths for best-effort upstream
 // compatibility. Pin the maintained PGSTY implementations used by SILO.
-replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e
+replace github.com/minio/console => github.com/pgsty/silo-console v0.0.0-20260907122901-0ab4a0ee4f8e
 
 replace github.com/minio/mc => github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9
 

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwp
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9 h1:kJkqK0hJrmvdTOPiI98HoPmET0SHYI9+ytaTRzQdGAs=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9/go.mod h1:+j12ENu7ggWIaBY4nakGABVmkjfJgogzijHIbaJFSOk=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada h1:vJkxm7GTLL0AvIGIt+JxMfhjMO5+msmj4rLeFueTaG8=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
+github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a h1:cjrffMJfZlwvDOM+0qk+QwuV6MY/I5+d8ztZ4UWVzrM=
+github.com/pgsty/silo-console v0.0.0-20260907052338-a0e609cbc61a/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
 github.com/pgsty/silo-pkg/v3 v3.13.2 h1:Clw11c/J54Tx6pijNCWtXiC7e0fwP/f5Tgeb6fsXg2w=
 github.com/pgsty/silo-pkg/v3 v3.13.2/go.mod h1:0GmaDA0ArQ8bkAI/obiSNTBQzdgBu6W0e0olDCbyXXo=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwp
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9 h1:kJkqK0hJrmvdTOPiI98HoPmET0SHYI9+ytaTRzQdGAs=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9/go.mod h1:+j12ENu7ggWIaBY4nakGABVmkjfJgogzijHIbaJFSOk=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada h1:vJkxm7GTLL0AvIGIt+JxMfhjMO5+msmj4rLeFueTaG8=
-github.com/pgsty/silo-console v0.0.0-20260903111932-464a59d73ada/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
+github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e h1:5weC3n+nMbIzeMyGbvEljGT2cTOHilQeWJBnmkM4BPY=
+github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
 github.com/pgsty/silo-pkg/v3 v3.13.2 h1:Clw11c/J54Tx6pijNCWtXiC7e0fwP/f5Tgeb6fsXg2w=
 github.com/pgsty/silo-pkg/v3 v3.13.2/go.mod h1:0GmaDA0ArQ8bkAI/obiSNTBQzdgBu6W0e0olDCbyXXo=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwp
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9 h1:kJkqK0hJrmvdTOPiI98HoPmET0SHYI9+ytaTRzQdGAs=
 github.com/pgsty/mc v0.0.0-20260903063637-a2ef95c035d9/go.mod h1:+j12ENu7ggWIaBY4nakGABVmkjfJgogzijHIbaJFSOk=
-github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e h1:5weC3n+nMbIzeMyGbvEljGT2cTOHilQeWJBnmkM4BPY=
-github.com/pgsty/silo-console v0.0.0-20260907114254-f12494c6578e/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
+github.com/pgsty/silo-console v0.0.0-20260907122901-0ab4a0ee4f8e h1:X1RTZVC2KhL4aZOHS6z5zygVt6Gp6F5OQwWKYzUjvDc=
+github.com/pgsty/silo-console v0.0.0-20260907122901-0ab4a0ee4f8e/go.mod h1:lInRIXU5jctVcagYHkvDuFRUYm/eCOJ1VNt1tciTHso=
 github.com/pgsty/silo-pkg/v3 v3.13.2 h1:Clw11c/J54Tx6pijNCWtXiC7e0fwP/f5Tgeb6fsXg2w=
 github.com/pgsty/silo-pkg/v3 v3.13.2/go.mod h1:0GmaDA0ArQ8bkAI/obiSNTBQzdgBu6W0e0olDCbyXXo=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=


### PR DESCRIPTION
Superseded by #149, merged as `3abe0d95a51d5feb65ad08eeefe29308fdc38f33`. Its updated candidate and this PR have the identical Git tree `97e196e1ed67187acc2df1bad55a2bdbc1112754`; `git diff HEAD origin/main` is empty. All changes below are already on main. Closing this duplicate keeps the existing PR as the merge record.

SILO still embeds a Console revision from before the accepted pagination and dependency fixes. Pin the merged Console main commit `b39a84ada5e8`, whose full 35-job matrix and vulnerability checks passed, so the embedded UI includes bounded object-browser pages, corrected object operations, and transport failures that preserve login.

Bring in the paired server changes from #149: preserve the four supported WebSocket connection limits, enable embedded loopback proxy attribution, and return invalid proxy/limit settings as startup errors. The Console checksum conflict is resolved to the newer immutable revision; no local module replacement is committed. The original fix commits remain merge ancestors.

Validation: Console main [full matrix](https://github.com/pgsty/silo-console/actions/runs/34175945817) and [vulnerability checks](https://github.com/pgsty/silo-console/actions/runs/34175945800) pass. This PR runs the complete SILO Go CI and vulnerability workflows against the combined graph before merging. The startup configuration regression tests, default binary build, and regenerated CREDITS comparison pass locally. A browser smoke test against the clean `07c42e4d2e36` binary confirms that an aborted background request preserves login. With the anonymous per-client WebSocket limit set to 16, 16 connections succeed and the 17th receives HTTP 429.

Compatibility: the maintained SILO stack is the release target. Standalone Console defaults and explicit proxy-trust overrides remain unchanged. WebSocket limits keep their raw values and set/unset state; invalid settings fail startup. Documentation is prepared in pgsty/silo.pgsty.com#14. No tag, release or deployment is part of this PR.

Contributed under AGPL-3.0-or-later with DCO sign-offs; existing notices and upstream authorship are preserved.

Closes #147.
Closes #148.
