### PR TITLE
fix: forward the legal hold as an Object Lock header on federated CopyObject

### DIFF
--- a/cmd/object-copy-federation-legalhold_test.go
+++ b/cmd/object-copy-federation-legalhold_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2015-2026 MinIO, Inc.
+//
+// This file is part of MinIO Object Storage stack
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio/internal/auth"
+	objectlock "github.com/minio/minio/internal/bucket/object/lock"
+	xhttp "github.com/minio/minio/internal/http"
+)
+
+// enableBucketObjectLock puts a lock-enabled configuration on an existing
+// bucket so checkPutObjectLockAllowed accepts a legal-hold header instead of
+// rejecting the request with ErrInvalidBucketObjectLockConfiguration.
+func enableBucketObjectLock(t *testing.T, bucket string) {
+	t.Helper()
+	meta, err := globalBucketMetadataSys.Get(bucket)
+	if err != nil {
+		t.Fatalf("unable to read bucket metadata for %s: %v", bucket, err)
+	}
+	updated := meta
+	updated.ObjectLockConfigXML = enabledBucketObjectLockConfig
+	updated.VersioningConfigXML = enabledBucketVersioningConfig
+	// The XML alone is not enough: BucketMetadata keeps a parsed copy that the
+	// lookups actually read, and it is only populated by parseAllConfigs.
+	if err := updated.parseAllConfigs(t.Context(), newObjectLayerFn()); err != nil {
+		t.Fatalf("unable to parse bucket metadata for %s: %v", bucket, err)
+	}
+	globalBucketMetadataSys.Set(bucket, updated)
+}
+
+// legalHoldHeaders returns the forwarded legal-hold headers the remote saw,
+// separated into the real Object Lock header and the user-metadata spelling
+// minio-go produces for an unrecognised UserMetadata key.
+func (c *federationRemoteCapture) legalHoldHeaders() (typed, asMetadata []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	metaKey := "X-Amz-Meta-" + xhttp.AmzObjectLockLegalHold
+	for _, h := range c.headers {
+		for k, v := range h {
+			switch {
+			case strings.EqualFold(k, xhttp.AmzObjectLockLegalHold):
+				typed = append(typed, strings.Join(v, ","))
+			case strings.EqualFold(k, metaKey):
+				asMetadata = append(asMetadata, strings.Join(v, ","))
+			}
+		}
+	}
+	return typed, asMetadata
+}
+
+// TestAPIFederatedCopyObjectLegalHold drives the legacy etcd federation branch
+// of CopyObjectHandler with an explicit legal hold on the copy.
+//
+// Before the fix the resolved hold was forwarded inside
+// PutObjectOptions.UserMetadata. minio-go's Header() prefixes every
+// UserMetadata key it does not recognise with "x-amz-meta-", and
+// x-amz-object-lock-legal-hold is in neither supportedHeaders nor isAmzHeader,
+// so the hold reached the remote as X-Amz-Meta-X-Amz-Object-Lock-Legal-Hold.
+// The destination stored no hold and the copy still answered 200 -- a silent
+// loss of a WORM control (#166). Retention requested on the same copy survived,
+// which is what made it easy to miss.
+func TestAPIFederatedCopyObjectLegalHold(t *testing.T) {
+	defer DetectTestLeak(t)()
+	ExecObjectLayerAPITest(ExecObjectLayerAPITestArgs{
+		t:          t,
+		objAPITest: testAPIFederatedCopyObjectLegalHold,
+		endpoints:  []string{"CopyObject", "PutObject", "HeadObject", "GetObject"},
+	})
+}
+
+func testAPIFederatedCopyObjectLegalHold(objectAPI ObjectLayer, instanceType, bucketName string,
+	apiRouter http.Handler, credentials auth.Credentials, t *testing.T,
+) {
+	data := []byte("federated copy with a legal hold")
+	srcObject := "federation/legal-hold-source"
+	putCopyChecksumSource(t, apiRouter, credentials, bucketName, srcObject, data, nil)
+
+	remoteBucket, capture, cleanup := setupCopyObjectFederation(t, objectAPI, apiRouter, instanceType, bucketName)
+	defer cleanup()
+
+	// Both roles read bucket metadata from the shared backend in this fixture,
+	// so one configuration covers the proxy's own check and the remote's.
+	enableBucketObjectLock(t, bucketName)
+	enableBucketObjectLock(t, remoteBucket)
+
+	dstObject := "federation/legal-hold-destination"
+	rec := federatedCopyRequest(t, apiRouter, credentials, bucketName, srcObject, remoteBucket, dstObject,
+		map[string]string{xhttp.AmzObjectLockLegalHold: string(objectlock.LegalHoldOn)})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s: federated CopyObject with a legal hold failed: %d %s",
+			instanceType, rec.Code, rec.Body.String())
+	}
+
+	// The wire is the point: the hold must arrive as the Object Lock header,
+	// never as user metadata. A 200 with the metadata spelling is exactly the
+	// silent loss this test exists for.
+	typed, asMetadata := capture.legalHoldHeaders()
+	if len(asMetadata) != 0 {
+		t.Fatalf("%s: legal hold forwarded as user metadata %v; the destination stores no hold",
+			instanceType, asMetadata)
+	}
+	if len(typed) == 0 {
+		t.Fatalf("%s: no %s header reached the remote deployment", instanceType, xhttp.AmzObjectLockLegalHold)
+	}
+	for _, got := range typed {
+		if !strings.EqualFold(got, string(objectlock.LegalHoldOn)) {
+			t.Fatalf("%s: forwarded legal hold = %q, want %q", instanceType, got, objectlock.LegalHoldOn)
+		}
+	}
+
+	// And it must actually be stored on the destination version.
+	oi, err := objectAPI.GetObjectInfo(t.Context(), remoteBucket, dstObject, ObjectOptions{})
+	if err != nil {
+		t.Fatalf("%s: unable to stat the federated copy destination: %v", instanceType, err)
+	}
+	if hold := objectlock.GetObjectLegalHoldMeta(oi.UserDefined); hold.Status != objectlock.LegalHoldOn {
+		t.Fatalf("%s: destination legal hold = %q, want %q (metadata: %v)",
+			instanceType, hold.Status, objectlock.LegalHoldOn, oi.UserDefined)
+	}
+}

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1945,10 +1945,35 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 				delete(srcInfo.UserDefined, k)
 			}
 		}
+		// Legal hold does not survive the metadata map. minio-go's Header()
+		// writes the typed lock fields first, then prefixes every UserMetadata
+		// key it does not recognise with "x-amz-meta-": supportedHeaders lists
+		// x-amz-object-lock-mode and x-amz-object-lock-retain-until-date but not
+		// x-amz-object-lock-legal-hold, and isAmzHeader does not match it
+		// either. Forwarded in the map the hold arrives as
+		// X-Amz-Meta-X-Amz-Object-Lock-Legal-Hold, the destination stores no
+		// hold, and the copy still answers 200 (#166).
+		//
+		// Carry only the hold on the typed field, and forward a clone without
+		// the raw key: typed fields are written before the UserMetadata loop, so
+		// a leftover raw key would add a bogus x-amz-meta- entry beside the
+		// correct header. Retention stays in the map -- it already passes
+		// through as a standard header, and moving it to the typed
+		// RetainUntilDate field would truncate the date to whole seconds.
+		legalHoldKey := strings.ToLower(xhttp.AmzObjectLockLegalHold)
+		forwardedLegalHold := srcInfo.UserDefined[legalHoldKey]
+		forwardedMeta := srcInfo.UserDefined
+		if forwardedLegalHold != "" {
+			forwardedMeta = cloneMSS(srcInfo.UserDefined)
+			delete(forwardedMeta, legalHoldKey)
+		}
 		opts := miniogo.PutObjectOptions{
-			UserMetadata:         srcInfo.UserDefined,
+			UserMetadata:         forwardedMeta,
 			ServerSideEncryption: dstOpts.ServerSideEncryption,
 			UserTags:             tag.ToMap(),
+		}
+		if forwardedLegalHold != "" {
+			opts.LegalHold = miniogo.LegalHoldStatus(forwardedLegalHold)
 		}
 		// The destination must carry the same checksum the local path would
 		// produce; the federated path has the remote compute, validate, persist
@@ -1996,7 +2021,10 @@ func (api objectAPIHandlers) CopyObjectHandler(w http.ResponseWriter, r *http.Re
 			writeErrorResponse(ctx, w, toAPIError(ctx, rerr), r.URL)
 			return
 		}
-		objInfo.UserDefined = cloneMSS(opts.UserMetadata)
+		// Built from the resolved values rather than the forwarding map: the
+		// legal hold was moved onto the typed option above, so opts.UserMetadata
+		// no longer carries it and the response and event would under-report.
+		objInfo.UserDefined = cloneMSS(srcInfo.UserDefined)
 		// A forwarded checksum header is a request detail, not object metadata.
 		if checksumHeaderValue != "" {
 			delete(objInfo.UserDefined, wantChecksumType.Key())


### PR DESCRIPTION
Fixes #166.

## The loss

A federated `CopyObject` requesting `x-amz-object-lock-legal-hold: ON` answered **200** with the destination carrying **no hold**. The resolved value arrived at the remote as `X-Amz-Meta-X-Amz-Object-Lock-Legal-Hold`, which nothing applies. Retention requested on the same copy survived, so the response and the retention state both looked right.

## Root cause, re-checked against the selected minio-go

The federation branch hands the resolved metadata map to `Core.PutObject` as `PutObjectOptions.UserMetadata`. `Header()` writes the typed lock fields first and then classifies each `UserMetadata` key:

```go
for k, v := range opts.UserMetadata {
    if isAmzHeader(k) || isStandardHeader(k) || isStorageClassHeader(k) || isMinioHeader(k) {
        header.Set(k, v)
    } else {
        header.Set("x-amz-meta-"+k, v)
    }
}
```

- `supportedHeaders` lists `x-amz-object-lock-mode` and `x-amz-object-lock-retain-until-date`, **not** `x-amz-object-lock-legal-hold`
- `isAmzHeader` matches only `x-amz-meta-`, `x-amz-grant-`, `x-amz-acl`, SSE and `x-amz-checksum-`

So the hold falls to the `else` and retention does not. `PutObjectOptions.validate()` would have rejected the key, but `Core.PutObject` goes straight to the low-level PUT and never calls it.

## The change

Move **only** the hold onto the typed field and forward a clone without the raw key.

The clone is load-bearing twice:

- typed fields are written *before* the `UserMetadata` loop, so a leftover raw key would add a bogus `x-amz-meta-` entry beside the correct header;
- `objInfo.UserDefined` (the copy response and the event) is now rebuilt from the resolved values rather than from `opts.UserMetadata`, which no longer carries the hold. Building it from the forwarding map would under-report a hold the proxy did apply.

**Retention deliberately stays in the map.** It already passes through as a standard header, and moving it to the typed `RetainUntilDate` field would format with `time.RFC3339` and truncate a retain-until date such as `2030-01-01T00:00:00.789Z` to whole seconds.

## Test

`TestAPIFederatedCopyObjectLegalHold` drives the legacy etcd federation branch through `setupCopyObjectFederation` and asserts the **wire**, since that is where the value was being lost:

- the remote receives `X-Amz-Object-Lock-Legal-Hold`
- it never receives the `x-amz-meta-` spelling
- the destination version actually stores the hold

It fails without the change with `legal hold forwarded as user metadata [ON]; the destination stores no hold`.

One fixture note: the helper sets the lock configuration through `globalBucketMetadataSys` and calls `parseAllConfigs`. Writing `ObjectLockConfigXML` alone is not enough — `BucketMetadata` keeps a parsed copy that the lookups read, and without the parse the copy is rejected earlier with `400 InvalidRequest: Bucket is missing ObjectLockConfiguration`, which is the second failure mode noted in the issue.

```
go build ./cmd/...                                          ok
go vet ./cmd/                                               ok
go test ./cmd/ -run TestAPIFederatedCopyObjectLegalHold     ok
go test ./cmd/ -run 'TestAPIFederated|TestAPICopyObject|ObjectLock'   ok  (80s)
gofmt                                                       clean
```

## Scope

Only the federation serialization of the hold, as the issue scopes it. Untouched and tracked separately: #165 (a legal-hold header suppressing the bucket's default retention — after this change a hold-only federated copy stores the hold and no retention, which is the behaviour #165 is about), and the proxy validating Object Lock against its own configuration rather than the destination's.
