### PR TITLE
docs: align release notes and current component status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+## Unreleased — main as of 2026-09-13
+
+The coordinated source is merged through `5d955b5b7444f8a3ab550ce92713607998f89c0d`.
+**The latest published Server remains 20260903.** These changes are not in its
+binaries, packages or images. See the [component matrix](https://silo.pgsty.com/compatibility/versions/)
+and [complete commit range](https://github.com/pgsty/silo/compare/RELEASE.2026-09-03T13-18-01Z...5d955b5b7444f8a3ab550ce92713607998f89c0d).
+
+### Authorization and security
+
+- Reject unsigned `x-amz-*` request headers that could turn a signed PUT into a
+  copy of another object accessible to the signer (SN-2026-011). The latest
+  public Server is affected; the fix is on main. See [the advisory ledger](docs/security/advisories.md).
+- Align signed request fields with policy conditions and enforce header-only
+  presigned payload checksums. See [the signed-header review](https://silo.pgsty.com/blog/design/signed-header-coverage/).
+- **Breaking policy semantics:** separate self-service `admin:ChangeMyPassword`
+  from `admin:CreateUser`. Built-in read-only policies follow the split. Preserve
+  both denies if the previous combined restriction must survive upgrades or
+  rollback. Saved policies are not rewritten. Deploy with the matching Console
+  and pkg; see [the migration guide](docs/iam/password-permissions.md).
+
+### Object storage and replication
+
+- Add GET-frequency-based movement across pools, then preserve versions and
+  isolate writes during movement. Serialize and reconcile multi-pool object
+  writes, metadata updates, healing and conditional deletion; preserve shared
+  remote-tier references until their last local owner is removed.
+- Enforce `If-Match` on DELETE, preserve retention and independently ordered
+  Object Lock/tag updates, and correctly retransmit encrypted replicas.
+- Preserve plaintext part sizes and raw SSE-C replicas; prevent SSE-C
+  compression, honor key-rotation checksums, and complete attributes pagination.
+- Repair federated CopyObject checksums, destination timestamps, reserved
+  metadata, encrypted-object forwarding, legal hold and KMS context.
+- Make resync counters, target selection, cancellation and worker lifetimes
+  reflect actual work; complete delete-marker purges and report bounded MRF drops.
+- Converge bucket metadata with deterministic source state, deletion tombstones,
+  creation time recovery and diagnostics. The mixed-version export gate requires
+  coordinated upgrades before tombstones are exported. See [the #77 record](docs/investigations/issue-77-current.md).
+- Include per-bucket CORS in metadata export/import, close metadata publication
+  and logger races, and report effective bucket quotas in metrics.
+
+### Console, dependencies and delivery
+
+- Restore embedded Console login over loopback TLS, trusted-proxy handling and
+  all four WebSocket connection limits. Preserve Go TLS defaults across transports.
+- Directly require `github.com/pgsty/silo-pkg/v3` v3.14.0; select Console
+  `v0.0.0-20260913015128-417559bb2c97` and MC
+  `v0.0.0-20260913012246-4f609a4da3bb` with explicit PGSTY replacements.
+- Pin upstream minio-go `v7.3.1-0.20260910142817-60bd07042d49`; refresh Go x/*
+  modules and security fixes including bounded AMQP frame handling. Keep Go
+  1.27.1 and go-systemd v22.6.0's NetBSD compatibility replacement.
+- Refresh container base digests and build static curl 8.22.0 from verified
+  source for both Linux architectures. Pin the actual mcli 20260913 archives and
+  hashes. Helm's client image follows that release; its Server image still names
+  the latest published Server 20260903.
+
+The dependency update passed the final candidate's Go, vulnerability and Test
+Release workflows; native curl builds passed on both architectures. A local
+ARM64 image passed startup, health, S3 transfer and embedded Console checks.
+These checks do not publish a Server tag or production image and do not replace
+cluster upgrade/rollback acceptance for the next release. Dated investigations
+retain the exact source and runtime boundaries they tested.
+
+## RELEASE.2026-09-03T13-18-01Z
+
+Published source: `9b11dc9469e650815b775cb47b039610644f5da4`.
+[Complete release notes](https://silo.pgsty.com/blog/release/silo-20260903/) ·
+[GitHub release](https://github.com/pgsty/silo/releases/tag/RELEASE.2026-09-03T13-18-01Z)
+
+This release ships Go 1.27.1, silo-pkg v3.13.2, upstream minio-go `0e78d3f18efe`,
+mcli 20260903 and embedded Console source `464a59d73ada` (v2.3.0 version identity).
+Installing the newer standalone mcli or Console does not replace components
+inside this existing Server binary or image.
+
+Earlier releases: [release archive](https://github.com/pgsty/silo/releases).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
 > [!NOTE]
 > Renamed from `pgsty/minio` to `pgsty/silo`, default branch `master` → `main`, on 2026-08-06. Artifacts under the original MinIO identity stay published on the archived [`minio`](https://github.com/pgsty/silo/tree/minio) branch and in releases up to [`RELEASE.2026-08-04T00-00-00Z`](https://github.com/pgsty/silo/releases/tag/RELEASE.2026-08-04T00-00-00Z).
 
+## Current release and main branch
+
+The latest published Server is [20260903](https://github.com/pgsty/silo/releases/tag/RELEASE.2026-09-03T13-18-01Z).
+As of 2026-09-13, the main branch has newer security, storage, Console and
+shared-package changes that have not shipped in a Server release. See
+[CHANGELOG.md](CHANGELOG.md) and the [component version matrix](https://silo.pgsty.com/compatibility/versions/)
+for the exact release/source boundary, including SN-2026-011 and password-policy migration.
+
 ## Overview
 
 PGSTY SILO keeps one maintained release line of the open-source MinIO server alive after upstream ended community distribution: builds, packages, multi-arch images, security fixes, and the full web console. Pigsty runs it in production as its PostgreSQL backup repository.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -35,6 +35,13 @@
 > [!NOTE]
 > 2026-08-06，本仓库由 `pgsty/minio` 更名为 `pgsty/silo`，默认分支由 `master` 更名为 `main`。以原 MinIO 形态维持的归档构件仍位于归档的 [`minio`](https://github.com/pgsty/silo/tree/minio) 分支，以及截止 [`RELEASE.2026-08-04T00-00-00Z`](https://github.com/pgsty/silo/releases/tag/RELEASE.2026-08-04T00-00-00Z) 的历次发布中。
 
+## 当前发行版与主分支
+
+最新已发布的 Server 仍为 [20260903](https://github.com/pgsty/silo/releases/tag/RELEASE.2026-09-03T13-18-01Z)。
+截至 2026-09-13，主分支已合入更新的安全、存储、Console 与共享包改动，但尚未发布新 Server。
+准确的已发布/源码边界见 [CHANGELOG.md](CHANGELOG.md) 与[组件版本矩阵](https://silo.pgsty.com/zh/compatibility/versions/)，
+其中包括 SN-2026-011 修复状态与密码权限迁移要求。
+
 ## 概述
 
 上游停止社区发行后，Silo 为开源 MinIO 服务端维护一条持续可用的版本线：构建、软件包、多架构镜像、安全修复与完整 Web 控制台。Pigsty 在生产环境中用它承载 PostgreSQL 备份存储。

--- a/docs/iam/password-permissions.md
+++ b/docs/iam/password-permissions.md
@@ -1,5 +1,11 @@
 # Password and user-management permissions
 
+> **Release boundary, 2026-09-13:** this guide describes Server main, paired with
+> silo-pkg v3.14.0 and Console source `417559bb2c97` or its accepted successor.
+> The latest published Server 20260903 and Console v2.4.0 do not contain this
+> split. The pkg v3.14.0 and mcli 20260913 releases alone do not change an old
+> Server's authorization. See [the component matrix](https://silo.pgsty.com/compatibility/versions/).
+
 **Breaking change: the password-permission split changes the meaning of
 existing IAM policies.** The same stored policy can authorize a request after
 this update that it denied before, or deny a request it previously authorized.

--- a/docs/investigations/go127-stack.md
+++ b/docs/investigations/go127-stack.md
@@ -1,5 +1,11 @@
 # SILO stack: Go 1.27 compatibility audit
 
+> This is a dated investigation, with the source and runtime boundaries recorded
+> below. It does not establish the current dependency pins or a later release.
+> See [the current changelog](../../CHANGELOG.md) and
+> [component matrix](https://silo.pgsty.com/compatibility/versions/).
+
+
 2026-09-09. Scope: the maintained Server, silo-pkg, mcli, and Console. This extends
 the [OIDC #154 investigation](issue-154.md) to other paths using the same TLS
 configuration and to adjacent standard-library changes. It records local

--- a/docs/investigations/issue-154.md
+++ b/docs/investigations/issue-154.md
@@ -1,5 +1,11 @@
 # SILO #154：OIDC discovery 连接重置调查
 
+> This is a dated investigation, with the source and runtime boundaries recorded
+> below. It does not establish the current dependency pins or a later release.
+> See [the current changelog](../../CHANGELOG.md) and
+> [component matrix](https://silo.pgsty.com/compatibility/versions/).
+
+
 前两轮调查时间：2026-09-09；公开 issue 最后核对于 07:53 UTC。第二轮补充同源码、同依赖、不同 Go 工具链的 Linux 完整 Server 对照和候选补丁认证链路验证。
 
 **后续更新：用户已授权扩展至整个 SILO 技术栈并修复。现已确认 Server 其他 TLS 路径也存在同类覆盖问题，并在产品工作区完成统一使用 Go 默认曲线的修复。当前实现、验证和交付状态见 [全栈调查](go127-stack.md)。下文保留前两轮的诊断与当时的 OIDC 局部候选；“未修改产品”和“不要扩大范围”等表述仅适用于当时的调查阶段，局部候选已被后续全路径修复取代。**

--- a/docs/investigations/release-readiness-20260911.md
+++ b/docs/investigations/release-readiness-20260911.md
@@ -1,5 +1,11 @@
 # Remaining release correctness work, 2026-09-11
 
+> This is a dated investigation, with the source and runtime boundaries recorded
+> below. It does not establish the current dependency pins or a later release.
+> See [the current changelog](../../CHANGELOG.md) and
+> [component matrix](https://silo.pgsty.com/compatibility/versions/).
+
+
 This records the three work items agreed after the branch/PR consolidation:
 OIDC #154, Linux restart/readback #116, and the related multi-pool defects
 #133/#144. The maintained target is SILO with the PGSTY Console, mcli and

--- a/docs/security/advisories.md
+++ b/docs/security/advisories.md
@@ -12,6 +12,14 @@ The first Silo community release was cut from upstream history that already cont
 | :-- | :-- | :-- | :-- | :-- |
 | [CVE-2025-62506](https://github.com/advisories/GHSA-jjjj-jwhf-8rgr) | [minio/minio#21642](https://github.com/minio/minio/pull/21642), merged as [`c1a49490`](https://github.com/minio/minio/commit/c1a49490c78e9c3ebcad86ba0662319138ace190) | The same commit object is present as [`pgsty/silo@c1a49490`](https://github.com/pgsty/silo/commit/c1a49490c78e9c3ebcad86ba0662319138ace190) | The inherited [service-account](https://github.com/pgsty/silo/blob/c1a49490c78e9c3ebcad86ba0662319138ace190/cmd/admin-handlers-users_test.go#L211-L212) and [STS](https://github.com/pgsty/silo/blob/c1a49490c78e9c3ebcad86ba0662319138ace190/cmd/sts-handlers_test.go#L45-L46) regression groups run for root and non-root parents through `go test ./cmd` | Resets `DenyOnly` while evaluating a restricted session policy so service or STS accounts cannot mint an unrestricted child service account. Upstream first fixed this in [`RELEASE.2025-10-15T17-29-55Z`](https://github.com/minio/minio/releases/tag/RELEASE.2025-10-15T17-29-55Z); every Silo community release, beginning with [`RELEASE.2025-12-03T12-00-00Z`](https://github.com/pgsty/silo/releases/tag/RELEASE.2025-12-03T12-00-00Z), contains it. Operators migrating from an older upstream build should upgrade and audit service accounts created by restricted service or STS identities. |
 
+## Current release boundary (2026-09-13)
+
+The latest published Server is `RELEASE.2026-09-03T13-18-01Z`.
+SN-2026-011 is fixed on main but remains present in that release and all earlier
+public Server releases. A newer mcli, pkg or standalone Console does not patch
+an installed Server. See [CHANGELOG.md](../../CHANGELOG.md) and the
+[component matrix](https://silo.pgsty.com/compatibility/versions/) for source pins.
+
 ## Advisories since `RELEASE.2026-03-21T00-00-00Z`
 
 | ID | Fixed by | Affected area | Remote exploitability | Summary | Upgrade / workaround notes |


### PR DESCRIPTION
Record Server 20260903 as the latest public release and summarize subsequent main-branch security, storage, Console and dependency changes under Unreleased. Clarify the embedded Console source, password-policy migration boundary and SN-2026-011 release status; label dated investigations as historical evidence.

Validation: tag/module graph and commit reachability checked; documentation-only diff check passed. No new Server tag or image is published by this documentation update.
